### PR TITLE
chore: strip comment bloat across the codebase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.9.1
+
+- Strip the comment bloat that had accumulated across the Dockerfiles, container entrypoints, wrapper scripts and CLI sources: file-level header blocks, section banners, and every comment that restated the line below it are gone, leaving at most one short line of JSDoc per function and one line above genuinely non-obvious logic. Behaviour is unchanged — the diff is comment-only
+
 ## 3.9.0
 
 - Migrate the CCR image to **claude-code-router 3.x**, which fixes the broken weekly image build: CCR `3.0.0` added a hard `better-sqlite3` dependency that `bun install` cannot build (its `prebuild-install` path is unsupported under bun, and it fell back to `node-gyp` with no Python in the image)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Why it's safe:
 - Host credentials and config are mounted **read-only** and injected into the container's own copies — nothing is ever written back to the host.
 - The image is hardened Ubuntu **26.04 LTS**: root is locked, the container user is a fixed non-root UID (`1000`), and no ports are published.
 
-**Current version: 3.9.0** — see the [CHANGELOG](CHANGELOG.md).
+**Current version: 3.9.1** — see the [CHANGELOG](CHANGELOG.md).
 
 ## Contents
 

--- a/docker/antigravity.dockerfile
+++ b/docker/antigravity.dockerfile
@@ -2,7 +2,6 @@ FROM ubuntu:26.04
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-# ── Root phase: system-level setup only ──────────────────────────────────────
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         git \
@@ -12,64 +11,46 @@ RUN apt-get update \
         unzip \
     && rm -rf /var/lib/apt/lists/*
 
-# Rename the built-in ubuntu user/group (UID/GID 1000) to viber and move its home.
 RUN usermod -l viber -d /home/viber -m ubuntu \
     && groupmod -n viber ubuntu
 
-# Pre-create the Homebrew prefix directory and hand it to viber
-# (the install script targets /home/linuxbrew/.linuxbrew on Linux)
 RUN mkdir -p /home/linuxbrew && chown viber:viber /home/linuxbrew
 
-# Seed directory: populated after brew installs so the runtime volume can be
-# initialized on first run without requiring root inside the container.
 RUN mkdir -p /opt/linuxbrew-seed && chown viber:viber /opt/linuxbrew-seed
 
-# Lock root: remove login shell and lock the password before dropping privileges
 RUN passwd -l root && usermod -s /usr/sbin/nologin root
 
-# ── Drop to non-root — root is no longer reachable from this point ───────────
 USER viber
 WORKDIR /home/viber/app
 
-# Install Homebrew as viber (non-root, installs to /home/linuxbrew/.linuxbrew)
 RUN curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh | bash
 
-# Expose brew on PATH for all subsequent layers and the running container
 ENV PATH="/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:${PATH}"
 
 RUN brew update && \
     brew install gcc
 
-# Install bun from its official installer into ~/.bun (a normal image layer, NOT the
-# brew volume). bun is this container's PID 1 (ENTRYPOINT below), so it must never live
-# under /home/linuxbrew, which the resettable secure-vibe-brew volume shadows at runtime.
+# bun is PID 1, so it must live in an image layer and never under /home/linuxbrew,
+# which the resettable secure-vibe-brew volume shadows at runtime.
 RUN curl -fsSL https://bun.sh/install | bash
 ENV PATH="/home/viber/.bun/bin:${PATH}"
 
-# Copy linuxbrew into the seed directory so the runtime volume can be populated
-# on first run even though /home/linuxbrew will be shadowed by a named volume.
 RUN cp -a /home/linuxbrew/. /opt/linuxbrew-seed/
 
-# Install the Antigravity CLI (`agy`, a Go single binary) into ~/.local/bin.
 RUN curl -fsSL https://antigravity.google/cli/install.sh | bash
 
 COPY --chown=viber:viber src/assets/sandbox-prompt.md /home/viber/.secure-vibe-sandbox.md
 
-# /home/viber/bin sits ahead of ~/.local/bin so the wrapper below shadows the
-# real agy binary on PATH — covers interactive shell, auto-start, AND the
-# explicit-command entrypoint path (which never sources .bashrc).
+# /home/viber/bin sits first so the wrapper below shadows the real agy on PATH,
+# including on the explicit-command entrypoint path, which never sources .bashrc.
 RUN mkdir -p /home/viber/bin
 ENV PATH="/home/viber/bin:/home/viber/.local/bin:${PATH}"
 
 COPY --chown=viber:viber src/assets/antigravity-wrapper.sh /home/viber/bin/agy
 RUN chmod +x /home/viber/bin/agy
 
-# Save the vanilla agy command into a symlink (escape hatch)
 RUN ln -s /home/viber/.local/bin/agy /home/viber/bin/agy-default
 
-# Auto-start + escape hatch appended to .bashrc. `agy` resolves through PATH
-# to the wrapper above; no alias needed. The SHLVL guard ensures auto-start
-# fires only on the outermost bash, not on sub-shells.
 COPY --chown=viber:viber src/assets/antigravity-bashrc-append.sh /tmp/bashrc-append.sh
 RUN cat /tmp/bashrc-append.sh >> /home/viber/.bashrc && rm /tmp/bashrc-append.sh
 

--- a/docker/ccr.dockerfile
+++ b/docker/ccr.dockerfile
@@ -2,11 +2,8 @@ FROM ubuntu:26.04
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-# ── Root phase: system-level setup only ──────────────────────────────────────
-# nodejs (22.x on Ubuntu 26.04, ABI 127) is required by CCR 3.x, which needs a real Node
-# and a native better-sqlite3. npm is deliberately NOT installed — pnpm below is the package
-# manager. python3 is deliberately absent too: a missing better-sqlite3 prebuild must fail
-# fast rather than silently node-gyp-compiling under QEMU.
+# No npm and no python3 on purpose: pnpm is the package manager, and a missing
+# better-sqlite3 prebuild must fail fast rather than node-gyp-compile under QEMU.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         git \
@@ -17,53 +14,32 @@ RUN apt-get update \
         nodejs \
     && rm -rf /var/lib/apt/lists/*
 
-# Rename the built-in ubuntu user/group (UID/GID 1000) to viber and move its home.
 RUN usermod -l viber -d /home/viber -m ubuntu \
     && groupmod -n viber ubuntu
 
-# Pre-create the Homebrew prefix directory and hand it to viber
-# (the install script targets /home/linuxbrew/.linuxbrew on Linux)
 RUN mkdir -p /home/linuxbrew && chown viber:viber /home/linuxbrew
 
-# Seed directory: populated after brew installs so the runtime volume can be
-# initialized on first run without requiring root inside the container.
 RUN mkdir -p /opt/linuxbrew-seed && chown viber:viber /opt/linuxbrew-seed
 
-# Lock root: remove login shell and lock the password before dropping privileges
 RUN passwd -l root && usermod -s /usr/sbin/nologin root
 
-# ── Drop to non-root — root is no longer reachable from this point ───────────
 USER viber
 WORKDIR /home/viber/app
 
-# Install Homebrew as viber (non-root, installs to /home/linuxbrew/.linuxbrew)
 RUN curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh | bash
 
-# Expose brew on PATH for all subsequent layers and the running container
 ENV PATH="/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:${PATH}"
 
 RUN brew update && \
     brew install gcc
 
-# Install bun from its official installer into ~/.bun (a normal image layer, NOT the
-# brew volume). bun is this container's PID 1 (ENTRYPOINT below), so it must never live
-# under /home/linuxbrew, which the resettable secure-vibe-brew volume shadows at runtime.
+# bun is PID 1, so it must live in an image layer and never under /home/linuxbrew,
+# which the resettable secure-vibe-brew volume shadows at runtime.
 RUN curl -fsSL https://bun.sh/install | bash
 ENV PATH="/home/viber/.bun/bin:${PATH}"
 
-# pnpm (self-contained, no npm) into an image layer. pnpm ≥10 refuses to run dependency
-# lifecycle scripts unless explicitly allowed — that is why it is used here instead of npm.
-#
-# The release tarball is fetched directly rather than via get.pnpm.io/install.sh: that script
-# delegates to `pnpm setup`, which detects the user's shell and edits a profile file to export
-# PATH. Neither applies in a Dockerfile, and it does not reliably land the binary in $PNPM_HOME.
-# Extracting the tarball ourselves makes the destination deterministic.
-#
-# Unpinned like the other installers here: the weekly no-cache rebuild tracks it, and both ways
-# this can break are LOUD — the `pnpm --version` check below catches a bad install, and pnpm
-# errors on unknown CLI options, so a renamed --allow-build fails the build rather than
-# silently dropping the allowlist.
-# $PNPM_HOME holds the pnpm binary; $PNPM_HOME/bin is where it links global package bins.
+# The tarball is fetched directly rather than via get.pnpm.io/install.sh, which delegates
+# to `pnpm setup` — a shell-profile editor that does nothing useful in a Dockerfile.
 ENV PNPM_HOME="/home/viber/.pnpm"
 ENV PATH="/home/viber/.pnpm:/home/viber/.pnpm/bin:${PATH}"
 RUN set -eu \
@@ -79,32 +55,17 @@ RUN set -eu \
     && chmod +x "$PNPM_HOME/pnpm" \
     && pnpm --version
 
-# Copy linuxbrew into the seed directory so the runtime volume can be populated
-# on first run even though /home/linuxbrew will be shadowed by a named volume.
 RUN cp -a /home/linuxbrew/. /opt/linuxbrew-seed/
 
-# Install the native Claude CLI (claude.ai/install.sh → ~/.local/bin). The wrappers below
-# launch it directly against CCR's gateway, adding the bypass flags + sandbox prompt.
 RUN curl -fsSL https://claude.ai/install.sh | bash
 
-# Install claude-code-router with pnpm into $PNPM_HOME — a normal image layer, NOT the
-# shadowed brew volume, so there's no seed-ordering risk. Unpinned on purpose: the weekly
-# no-cache CI rebuild picks up the latest CCR, same as the other provider images.
-#
-# --allow-build is an explicit, auditable allowlist: pnpm blocks ALL dependency install
-# scripts by default, and better-sqlite3 is the one package permitted to run its own
-# (prebuild-install, which downloads a prebuilt native binding — no compiler needed).
-# If a future CCR release adds another script-running dependency the build FAILS with
-# "Ignored build scripts: <pkg>" instead of silently executing it.
+# --allow-build is an explicit allowlist: pnpm blocks all dependency install scripts by
+# default, so a future CCR release adding one fails the build instead of running it.
 RUN pnpm add -g --allow-build=better-sqlite3 @musistudio/claude-code-router
 
-# Smoke check: assert the native binding actually loads under this Node's ABI — the exact
-# thing that broke the build when CCR 3.x introduced better-sqlite3. Resolving from the
-# package's own directory keeps this independent of pnpm's (opaque, versioned) global store
-# layout. Deliberately does NOT run `ccr serve`: that would create
-# ~/.claude-code-router/config.sqlite in the image, and CCR only imports config.json when no
-# sqlite store exists — baking one in would silently make every container ignore the user's
-# mounted config, forever, with no error.
+# Asserts the native binding loads under this Node's ABI. Deliberately does NOT run
+# `ccr serve`: that would bake a config.sqlite into the image, and CCR imports config.json
+# only when no sqlite store exists — every container would ignore the mounted config.
 RUN set -eu \
     && CCR_PKG="$(find "$PNPM_HOME" -path '*/@musistudio/claude-code-router/package.json' -print -quit)" \
     && test -n "$CCR_PKG" \
@@ -112,46 +73,29 @@ RUN set -eu \
 
 COPY --chown=viber:viber src/assets/sandbox-prompt.md /home/viber/.secure-vibe-sandbox.md
 
-# Starter config for the fallback scaffold path in the entrypoint (when no host config is
-# mounted). Same single source the host runner imports, so the two scaffolds never drift.
 COPY --chown=viber:viber src/assets/ccr-starter-config.json /home/viber/.ccr-starter-config.json
 
-# /home/viber/bin sits ahead of ~/.local/bin and ~/.bun/bin so our wrappers shadow the
-# real binaries on PATH — covers interactive shell, auto-start, AND the explicit-command
-# entrypoint path (which never sources .bashrc).
+# /home/viber/bin sits first so the wrappers below shadow the real binaries on PATH,
+# including on the explicit-command entrypoint path, which never sources .bashrc.
 RUN mkdir -p /home/viber/bin
 ENV PATH="/home/viber/bin:/home/viber/.local/bin:/home/viber/.bun/bin:${PATH}"
 
-# Command model — CCR 3.x dropped `ccr code`, so nothing spawns claude for us any more.
-# Instead the entrypoint runs `ccr serve` as a sidecar gateway and exports
-# ANTHROPIC_BASE_URL/ANTHROPIC_AUTH_TOKEN; these wrappers just launch the REAL claude by
-# absolute path (never recursing) against it. They differ only in permission posture:
-#   claude, ccr      → WITH --dangerously-skip-permissions
-#   claude-default   → WITHOUT bypass, normal prompts
-# Both append the sandbox T&Cs prompt, and both source the gateway env file so they work
-# even under `docker exec`, which inherits nothing from PID 1.
+# claude and ccr bypass permissions, claude-default keeps the normal prompts.
 COPY --chown=viber:viber src/assets/claude-bypass.sh /home/viber/bin/claude
 COPY --chown=viber:viber src/assets/claude-bypass.sh /home/viber/bin/ccr
 COPY --chown=viber:viber src/assets/claude-nobypass.sh /home/viber/bin/claude-default
 RUN chmod +x /home/viber/bin/claude /home/viber/bin/ccr /home/viber/bin/claude-default
 
-# Escape hatch to the raw ccr CLI (`ccr-default serve|stop|ui`), also used by the entrypoint
-# to start the gateway. pnpm links it as a /bin/sh shim, so it is exec'd rather than passed to
-# node; prepending /usr/bin means the node that shim finds is the ABI-matched one even if the
-# user later runs `brew install node` (brew sits ahead of /usr/bin on PATH). The test -x makes
-# a future change to pnpm's global bin layout fail the build loudly instead of at runtime.
+# Prepending /usr/bin pins the ABI-matched node even if the user later brew-installs one.
 RUN test -x "$PNPM_HOME/bin/ccr" \
     && printf '#!/usr/bin/env bash\nexport PATH="/usr/bin:$PATH"\nexec "%s/bin/ccr" "$@"\n' "$PNPM_HOME" > /home/viber/bin/ccr-default \
     && chmod +x /home/viber/bin/ccr-default
 
-# CCR probes candidate node binaries before spawning its core gateway child; pin ours so the
-# brew volume can never change the answer at runtime. CCR 3.x always binds a local management
-# server too — keep it on loopback (no ports are published either way).
+# CCR probes candidate node binaries before spawning its gateway child; pin ours so the
+# brew volume can never change the answer, and keep its management server on loopback.
 ENV CCR_NODE_BIN="/usr/bin/node" \
     CCR_WEB_HOST="127.0.0.1"
 
-# Auto-start + PATH re-assertion appended to .bashrc. The SHLVL guard ensures
-# auto-start fires only on the outermost bash, not on sub-shells.
 COPY --chown=viber:viber src/assets/ccr-bashrc-append.sh /tmp/bashrc-append.sh
 RUN cat /tmp/bashrc-append.sh >> /home/viber/.bashrc && rm /tmp/bashrc-append.sh
 

--- a/docker/claude.dockerfile
+++ b/docker/claude.dockerfile
@@ -2,7 +2,6 @@ FROM ubuntu:26.04
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-# ── Root phase: system-level setup only ──────────────────────────────────────
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         git \
@@ -12,63 +11,46 @@ RUN apt-get update \
         unzip \
     && rm -rf /var/lib/apt/lists/*
 
-# Rename the built-in ubuntu user/group (UID/GID 1000) to viber and move its home.
 RUN usermod -l viber -d /home/viber -m ubuntu \
     && groupmod -n viber ubuntu
 
-# Pre-create the Homebrew prefix directory and hand it to viber
-# (the install script targets /home/linuxbrew/.linuxbrew on Linux)
 RUN mkdir -p /home/linuxbrew && chown viber:viber /home/linuxbrew
 
-# Seed directory: populated after brew installs so the runtime volume can be
-# initialized on first run without requiring root inside the container.
 RUN mkdir -p /opt/linuxbrew-seed && chown viber:viber /opt/linuxbrew-seed
 
-# Lock root: remove login shell and lock the password before dropping privileges
 RUN passwd -l root && usermod -s /usr/sbin/nologin root
 
-# ── Drop to non-root — root is no longer reachable from this point ───────────
 USER viber
 WORKDIR /home/viber/app
 
-# Install Homebrew as viber (non-root, installs to /home/linuxbrew/.linuxbrew)
 RUN curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh | bash
 
-# Expose brew on PATH for all subsequent layers and the running container
 ENV PATH="/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:${PATH}"
 
 RUN brew update && \
     brew install gcc
 
-# Install bun from its official installer into ~/.bun (a normal image layer, NOT the
-# brew volume). bun is this container's PID 1 (ENTRYPOINT below), so it must never live
-# under /home/linuxbrew, which the resettable secure-vibe-brew volume shadows at runtime.
+# bun is PID 1, so it must live in an image layer and never under /home/linuxbrew,
+# which the resettable secure-vibe-brew volume shadows at runtime.
 RUN curl -fsSL https://bun.sh/install | bash
 ENV PATH="/home/viber/.bun/bin:${PATH}"
 
-# Copy linuxbrew into the seed directory so the runtime volume can be populated
-# on first run even though /home/linuxbrew will be shadowed by a named volume.
 RUN cp -a /home/linuxbrew/. /opt/linuxbrew-seed/
 
 RUN curl -fsSL https://claude.ai/install.sh | bash
 
 COPY --chown=viber:viber src/assets/sandbox-prompt.md /home/viber/.secure-vibe-sandbox.md
 
-# /home/viber/bin sits ahead of ~/.local/bin so the wrapper below shadows the
-# real claude binary on PATH — covers interactive shell, auto-start, AND the
-# explicit-command entrypoint path (which never sources .bashrc).
+# /home/viber/bin sits first so the wrapper below shadows the real claude on PATH,
+# including on the explicit-command entrypoint path, which never sources .bashrc.
 RUN mkdir -p /home/viber/bin
 ENV PATH="/home/viber/bin:/home/viber/.local/bin:${PATH}"
 
 COPY --chown=viber:viber src/assets/claude-wrapper.sh /home/viber/bin/claude
 RUN chmod +x /home/viber/bin/claude
 
-# Save the vanilla claude command into a symlink
 RUN ln -s /home/viber/.local/bin/claude /home/viber/bin/claude-default
 
-# Auto-start + escape hatch appended to .bashrc. `claude` resolves through PATH
-# to the wrapper above; no alias needed. The SHLVL guard ensures auto-start
-# fires only on the outermost bash, not on sub-shells.
 COPY --chown=viber:viber src/assets/bashrc-append.sh /tmp/bashrc-append.sh
 RUN cat /tmp/bashrc-append.sh >> /home/viber/.bashrc && rm /tmp/bashrc-append.sh
 

--- a/docker/codex.dockerfile
+++ b/docker/codex.dockerfile
@@ -2,7 +2,6 @@ FROM ubuntu:26.04
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-# ── Root phase: system-level setup only ──────────────────────────────────────
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         git \
@@ -12,77 +11,53 @@ RUN apt-get update \
         unzip \
     && rm -rf /var/lib/apt/lists/*
 
-# Rename the built-in ubuntu user/group (UID/GID 1000) to viber and move its home.
 RUN usermod -l viber -d /home/viber -m ubuntu \
     && groupmod -n viber ubuntu
 
-# Pre-create the Homebrew prefix directory and hand it to viber
-# (the install script targets /home/linuxbrew/.linuxbrew on Linux)
 RUN mkdir -p /home/linuxbrew && chown viber:viber /home/linuxbrew
 
-# Seed directory: populated after brew installs so the runtime volume can be
-# initialized on first run without requiring root inside the container.
 RUN mkdir -p /opt/linuxbrew-seed && chown viber:viber /opt/linuxbrew-seed
 
-# Lock root: remove login shell and lock the password before dropping privileges
 RUN passwd -l root && usermod -s /usr/sbin/nologin root
 
-# ── Drop to non-root — root is no longer reachable from this point ───────────
 USER viber
 WORKDIR /home/viber/app
 
-# Install Homebrew as viber (non-root, installs to /home/linuxbrew/.linuxbrew)
 RUN curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh | bash
 
-# Expose brew on PATH for all subsequent layers and the running container
 ENV PATH="/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:${PATH}"
 
 RUN brew update && \
     brew install gcc
 
-# Install bun from its official installer into ~/.bun (a normal image layer, NOT the
-# brew volume). bun is this container's PID 1 (ENTRYPOINT below) AND the build step that
-# installs codex below runs through it, so it must never live under /home/linuxbrew, which
-# the resettable secure-vibe-brew volume shadows at runtime.
+# bun is PID 1 and installs codex below, so it must live in an image layer and never under
+# /home/linuxbrew, which the resettable secure-vibe-brew volume shadows at runtime.
 RUN curl -fsSL https://bun.sh/install | bash
 ENV PATH="/home/viber/.bun/bin:${PATH}"
 
-# Copy linuxbrew into the seed directory so the runtime volume can be populated
-# on first run even though /home/linuxbrew will be shadowed by a named volume.
 RUN cp -a /home/linuxbrew/. /opt/linuxbrew-seed/
 
-# Install the Codex CLI with bun (no npm, no node). Lands in /home/viber/.bun —
-# a normal image layer, NOT the shadowed brew volume, so there's no seed-ordering risk.
-# Unpinned on purpose: the weekly no-cache CI rebuild picks up the latest codex,
-# same as the curl installers in the claude/antigravity images.
 RUN bun install -g @openai/codex
 
 COPY --chown=viber:viber src/assets/sandbox-prompt.md /home/viber/.secure-vibe-sandbox.md
 
-# /home/viber/bin sits ahead of ~/.bun/bin so our wrapper shadows the real binary
-# on PATH — covers interactive shell, auto-start, AND the explicit-command
-# entrypoint path (which never sources .bashrc).
+# /home/viber/bin sits first so the wrapper below shadows the real codex on PATH,
+# including on the explicit-command entrypoint path, which never sources .bashrc.
 RUN mkdir -p /home/viber/bin
 ENV PATH="/home/viber/bin:/home/viber/.bun/bin:${PATH}"
 
-# node→bun shim: codex's bin script has a `#!/usr/bin/env node` shebang (it dispatches
-# to the platform-native rust binary). The shim lets it — and the codex-default
-# escape hatch — run without a real node.
+# codex's bin script has a `#!/usr/bin/env node` shebang; this shim means no real node.
 RUN printf '#!/usr/bin/env bash\nexec bun "$@"\n' > /home/viber/bin/node \
     && chmod +x /home/viber/bin/node
 
-# Wrapper adds --dangerously-bypass-approvals-and-sandbox (the container is the sandbox).
 COPY --chown=viber:viber src/assets/codex-wrapper.sh /home/viber/bin/codex
 RUN chmod +x /home/viber/bin/codex
 
-# Escape hatch with normal approval prompts. A wrapper, not a symlink: it must
-# add --sandbox danger-full-access because bubblewrap can't create user
-# namespaces in the container (sandboxed commands would all fail).
+# A wrapper, not a symlink: it must disable codex's own sandbox, which cannot create
+# user namespaces inside the container.
 COPY --chown=viber:viber src/assets/codex-default.sh /home/viber/bin/codex-default
 RUN chmod +x /home/viber/bin/codex-default
 
-# Auto-start + PATH re-assertion appended to .bashrc. The SHLVL guard ensures
-# auto-start fires only on the outermost bash, not on sub-shells.
 COPY --chown=viber:viber src/assets/codex-bashrc-append.sh /tmp/bashrc-append.sh
 RUN cat /tmp/bashrc-append.sh >> /home/viber/.bashrc && rm /tmp/bashrc-append.sh
 

--- a/docker/vibe.dockerfile
+++ b/docker/vibe.dockerfile
@@ -2,7 +2,6 @@ FROM ubuntu:26.04
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-# ── Root phase: system-level setup only ──────────────────────────────────────
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         git \
@@ -12,75 +11,50 @@ RUN apt-get update \
         unzip \
     && rm -rf /var/lib/apt/lists/*
 
-# Rename the built-in ubuntu user/group (UID/GID 1000) to viber and move its home.
 RUN usermod -l viber -d /home/viber -m ubuntu \
     && groupmod -n viber ubuntu
 
-# Pre-create the Homebrew prefix directory and hand it to viber
-# (the install script targets /home/linuxbrew/.linuxbrew on Linux)
 RUN mkdir -p /home/linuxbrew && chown viber:viber /home/linuxbrew
 
-# Seed directory: populated after brew installs so the runtime volume can be
-# initialized on first run without requiring root inside the container.
 RUN mkdir -p /opt/linuxbrew-seed && chown viber:viber /opt/linuxbrew-seed
 
-# Lock root: remove login shell and lock the password before dropping privileges
 RUN passwd -l root && usermod -s /usr/sbin/nologin root
 
-# ── Drop to non-root — root is no longer reachable from this point ───────────
 USER viber
 WORKDIR /home/viber/app
 
-# Install Homebrew as viber (non-root, installs to /home/linuxbrew/.linuxbrew)
 RUN curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh | bash
 
-# Expose brew on PATH for all subsequent layers and the running container
 ENV PATH="/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:${PATH}"
 
 RUN brew update && \
     brew install gcc
 
-# Install bun from its official installer into ~/.bun (a normal image layer, NOT the
-# brew volume). bun is this container's PID 1 (ENTRYPOINT below), so it must never live
-# under /home/linuxbrew, which the resettable secure-vibe-brew volume shadows at runtime.
+# bun is PID 1, so it must live in an image layer and never under /home/linuxbrew,
+# which the resettable secure-vibe-brew volume shadows at runtime.
 RUN curl -fsSL https://bun.sh/install | bash
 ENV PATH="/home/viber/.bun/bin:${PATH}"
 
-# Copy linuxbrew into the seed directory so the runtime volume can be populated
-# on first run even though /home/linuxbrew will be shadowed by a named volume.
 RUN cp -a /home/linuxbrew/. /opt/linuxbrew-seed/
 
-# Install Mistral Vibe with its official installer: it bootstraps uv into ~/.local/bin,
-# then `uv tool install mistral-vibe`, which auto-provisions a managed CPython (vibe
-# needs Python ≥ 3.12) under ~/.local/share/uv. Everything lands in normal image layers
-# under /home/viber — NOT the shadowed brew volume — so there's no seed-ordering risk.
-# Unpinned on purpose: the weekly no-cache CI rebuild picks up the latest vibe, same as
-# the curl installers in the claude/antigravity images. PATH is pre-extended so the
-# installer finds the uv it just installed.
+# PATH is pre-extended so the installer finds the uv it bootstraps a line earlier.
 RUN export PATH="/home/viber/.local/bin:$PATH" \
     && curl -LsSf https://mistral.ai/vibe/install.sh | bash
 
 COPY --chown=viber:viber src/assets/sandbox-prompt.md /home/viber/.secure-vibe-sandbox.md
 
-# /home/viber/bin sits ahead of ~/.local/bin so the wrapper below shadows the
-# real vibe binary on PATH — covers interactive shell, auto-start, AND the
-# explicit-command entrypoint path (which never sources .bashrc).
+# /home/viber/bin sits first so the wrapper below shadows the real vibe on PATH,
+# including on the explicit-command entrypoint path, which never sources .bashrc.
 RUN mkdir -p /home/viber/bin
 ENV PATH="/home/viber/bin:/home/viber/.local/bin:${PATH}"
 
-# Build-time smoke check: fails the build if the vibe install is broken.
 RUN vibe --version
 
-# Wrapper adds --yolo (the container is the sandbox).
 COPY --chown=viber:viber src/assets/vibe-wrapper.sh /home/viber/bin/vibe
 RUN chmod +x /home/viber/bin/vibe
 
-# Escape hatch with normal approval prompts: vibe has no internal OS sandbox to
-# disable (unlike codex's bwrap), so a plain symlink to the vanilla binary works.
 RUN ln -s /home/viber/.local/bin/vibe /home/viber/bin/vibe-default
 
-# Auto-start + PATH re-assertion appended to .bashrc. The SHLVL guard ensures
-# auto-start fires only on the outermost bash, not on sub-shells.
 COPY --chown=viber:viber src/assets/vibe-bashrc-append.sh /tmp/bashrc-append.sh
 RUN cat /tmp/bashrc-append.sh >> /home/viber/.bashrc && rm /tmp/bashrc-append.sh
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.9.0",
+  "version": "3.9.1",
   "scripts": {
     "start": "bun src/index.ts",
     "vibe": "bun run start",

--- a/scripts/alias.ts
+++ b/scripts/alias.ts
@@ -10,16 +10,8 @@ const START = "# secure-vibe alias (start)"
 const END = "# secure-vibe alias (end)"
 const LEGACY_MARKER = "# secure-vibe alias"
 
-// A shell FUNCTION, not an alias: zsh expands aliases before attempting completion,
-// which bypasses the `compdef secure-vibe` registration and breaks tab-completion.
-// A function isn't expanded that way, behaves identically for the user, and works
-// in both bash and zsh.
-//
-// The leading `unalias` drops any stale alias of the same name first (e.g. one left
-// active in the current shell from a previous setup). Without it, zsh/bash expand the
-// alias while parsing the function line below and abort with
-// "defining function based on alias". It runs on its own line so the removal takes
-// effect before the next line is parsed.
+// A function, not an alias: zsh expands aliases before completion, which bypasses `compdef`.
+// The `unalias` line clears a stale alias first, or defining the function below aborts.
 const FUNCTION_DEF = [
   `unalias ${NAME} 2>/dev/null || true`,
   `${NAME}() { bun "${ENTRYPOINT}" "$@"; }`
@@ -37,8 +29,7 @@ function stripBlock(content: string): string {
     if(end !== -1) content = content.slice(0, start) + content.slice(end + END.length)
   }
 
-  // Drop a legacy "# secure-vibe alias\nalias secure-vibe=…" block — left in place,
-  // the alias would shadow the new function in zsh and re-break completion.
+  // A legacy alias block left in place would shadow the function and re-break completion.
   const lines = content.split("\n")
   const keptLines: string[] = []
   for(let index = 0; index < lines.length; index++) {
@@ -73,5 +64,4 @@ if(shell.endsWith("zsh")) {
   addAlias(join(home, ".zsh_aliases"), join(home, ".zshrc"))
 }
 
-// Also install dynamic shell completion so `setup:alias` wires up both in one step.
 installCompletion()

--- a/scripts/completion.ts
+++ b/scripts/completion.ts
@@ -2,18 +2,6 @@ import { existsSync, readFileSync, writeFileSync } from "fs"
 import { join } from "path"
 import { DIRS_DIRECTIVE } from "../src/utils/completion"
 
-/**
- * Installs a dynamic shell-completion stub for the `secure-vibe` command.
- *
- * The stub holds NO flag knowledge — on each TAB it calls the live binary
- * (`bun .../src/index.ts __complete …`), which computes suggestions from the
- * FLAGS spec (src/constants/flags.ts). So completion never goes stale: upgrading
- * secure-vibe updates completion automatically, with no need to re-run setup.
- *
- * The block is written into the same aliases file the alias uses (~/.bash_aliases
- * or ~/.zsh_aliases) and is marker-guarded + idempotent — re-running replaces it.
- */
-
 const PROJECT_DIR = join(import.meta.dir, "..")
 const ENTRYPOINT = `${PROJECT_DIR}/src/index.ts`
 const START = "# secure-vibe completion (start)"
@@ -25,7 +13,6 @@ function bashBlock(): string {
     "_secure_vibe_complete() {",
     '  local cur="${COMP_WORDS[COMP_CWORD]}" out',
     `  out="$(bun "${ENTRYPOINT}" __complete "\${COMP_WORDS[@]:1:COMP_CWORD}" 2>/dev/null)"`,
-    // Strip the directory directive from the candidate list, then offer dirs too when it was present.
     `  COMPREPLY=( $(compgen -W "\${out//${DIRS_DIRECTIVE}/}" -- "$cur") )`,
     `  [[ "$out" == *${DIRS_DIRECTIVE}* ]] && COMPREPLY+=( $(compgen -d -- "$cur") )`,
     "}",
@@ -37,13 +24,10 @@ function bashBlock(): string {
 function zshBlock(): string {
   return [
     START,
-    // Ensure the completion system is initialised even if .zshrc hasn't run compinit yet.
     "(( $+functions[compdef] )) || { autoload -Uz compinit && compinit -u 2>/dev/null }",
     "_secure_vibe_complete() {",
     "  local -a out",
     `  out=( "\${(@f)$(bun "${ENTRYPOINT}" __complete "\${(@)words[2,CURRENT]}" 2>/dev/null)}" )`,
-    // When the directory directive is present, drop it from the list, add the flags/values
-    // (if any), then offer directories too. Otherwise just add whatever came back.
     `  if (( \${out[(I)${DIRS_DIRECTIVE}]} )); then`,
     `    out=( \${out:#${DIRS_DIRECTIVE}} )`,
     "    (( ${#out} )) && compadd -- $out",

--- a/src/assets/antigravity-bashrc-append.sh
+++ b/src/assets/antigravity-bashrc-append.sh
@@ -1,11 +1,8 @@
-# secure-vibe: the agy installer prepends ~/.local/bin to PATH in .bashrc, which
-# shadows our wrapper at /home/viber/bin (the wrapper adds --dangerously-skip-
-# permissions). This block runs last, so re-assert /home/viber/bin ahead of the
-# real binary and clear bash's command hash so `agy` resolves to the wrapper.
+# secure-vibe: the agy installer prepends ~/.local/bin here, shadowing our wrapper, so
+# re-assert /home/viber/bin last and clear bash's command hash.
 export PATH="/home/viber/bin:$PATH"
 hash -r 2>/dev/null || true
 
-# Auto-start antigravity on first interactive shell (now resolves to the wrapper).
 if [[ $SHLVL -eq 1 && -z "${SECURE_VIBE_EXPLICIT_CMD:-}" ]]; then
   agy || true
   echo ""

--- a/src/assets/antigravity-wrapper.sh
+++ b/src/assets/antigravity-wrapper.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-# No --sandbox: the container is the sandbox, and nsjail can't get namespaces here.
 exec /home/viber/.local/bin/agy \
   --dangerously-skip-permissions \
   "$@"

--- a/src/assets/ccr-bashrc-append.sh
+++ b/src/assets/ccr-bashrc-append.sh
@@ -1,14 +1,12 @@
 
-# secure-vibe: re-assert /home/viber/bin ahead of ~/.local/bin and ~/.bun/bin on PATH
-# so `ccr` and `claude` resolve to our wrappers, then clear bash's command hash so the
-# lookup re-resolves.
+# secure-vibe: re-assert /home/viber/bin last so `ccr` and `claude` resolve to our
+# wrappers, and clear bash's command hash so the lookup re-resolves.
 export PATH="/home/viber/bin:$PATH"
 hash -r 2>/dev/null || true
 
 # Gateway endpoint + token, written by the entrypoint once `ccr serve` is up.
 [[ -f /home/viber/.secure-vibe-ccr.env ]] && . /home/viber/.secure-vibe-ccr.env
 
-# Auto-start on the first interactive shell (resolves to the claude wrapper).
 if [[ $SHLVL -eq 1 && -z "${SECURE_VIBE_EXPLICIT_CMD:-}" ]]; then
   ccr || true
   echo ""

--- a/src/assets/claude-bypass.sh
+++ b/src/assets/claude-bypass.sh
@@ -1,11 +1,5 @@
 #!/usr/bin/env bash
-# Installed as BOTH `claude` and `ccr`. The whole point of this container is to route through
-# claude-code-router, so the bare `claude` command routes through it too — but in CCR 3.x that
-# means talking to the local gateway (`ccr serve`, started by the entrypoint) over
-# $ANTHROPIC_BASE_URL, not being spawned by `ccr code`, which no longer exists.
-#
-# The env file is the authority: PID 1 writes it, so this also works under `docker exec`,
-# which inherits nothing. Execs the REAL claude by absolute path so PATH can never recurse.
+# The env file is the authority: PID 1 writes it, so this works under `docker exec` too.
 [[ -f /home/viber/.secure-vibe-ccr.env ]] && . /home/viber/.secure-vibe-ccr.env
 
 exec /home/viber/.local/bin/claude \

--- a/src/assets/claude-nobypass.sh
+++ b/src/assets/claude-nobypass.sh
@@ -1,8 +1,4 @@
 #!/usr/bin/env bash
-# Installed as `claude-default`: same as the `claude` wrapper (still routed through CCR's local
-# gateway — nothing here reaches Anthropic directly) but WITHOUT
-# --dangerously-skip-permissions, so Claude Code keeps its normal permission prompts for when
-# you want to review each action. Still appends the sandbox T&Cs prompt.
 [[ -f /home/viber/.secure-vibe-ccr.env ]] && . /home/viber/.secure-vibe-ccr.env
 
 exec /home/viber/.local/bin/claude \

--- a/src/assets/codex-bashrc-append.sh
+++ b/src/assets/codex-bashrc-append.sh
@@ -1,11 +1,9 @@
 
-# secure-vibe: re-assert /home/viber/bin ahead of ~/.bun/bin on PATH so `codex`
-# resolves to our wrapper (which adds --dangerously-bypass-approvals-and-sandbox),
-# then clear bash's command hash so the lookup re-resolves.
+# secure-vibe: re-assert /home/viber/bin last so `codex` resolves to our wrapper, and
+# clear bash's command hash so the lookup re-resolves.
 export PATH="/home/viber/bin:$PATH"
 hash -r 2>/dev/null || true
 
-# Auto-start codex on first interactive shell (now resolves to the wrapper).
 if [[ $SHLVL -eq 1 && -z "${SECURE_VIBE_EXPLICIT_CMD:-}" ]]; then
   codex || true
   echo ""

--- a/src/assets/codex-default.sh
+++ b/src/assets/codex-default.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
-# Escape hatch: normal approval prompts, but codex's own sandbox stays off —
-# bubblewrap can't create user namespaces inside the container, so every
-# sandboxed command would fail. The container is the sandbox.
+# Escape hatch with normal approval prompts. codex's own sandbox stays off: bubblewrap
+# cannot create user namespaces in the container, so every sandboxed command would fail.
 exec /home/viber/.bun/bin/codex \
   --sandbox danger-full-access \
   "$@"

--- a/src/assets/codex-wrapper.sh
+++ b/src/assets/codex-wrapper.sh
@@ -1,6 +1,4 @@
 #!/usr/bin/env bash
-# No --sandbox mode: the container is the sandbox. codex's bin script has a node
-# shebang; /home/viber/bin/node is a bun shim, so no real node is ever needed.
 exec /home/viber/.bun/bin/codex \
   --dangerously-bypass-approvals-and-sandbox \
   "$@"

--- a/src/assets/vibe-bashrc-append.sh
+++ b/src/assets/vibe-bashrc-append.sh
@@ -1,11 +1,9 @@
 
-# secure-vibe: re-assert /home/viber/bin ahead of ~/.local/bin on PATH so `vibe`
-# resolves to our wrapper (which adds --yolo), then clear bash's command hash so
-# the lookup re-resolves.
+# secure-vibe: re-assert /home/viber/bin last so `vibe` resolves to our wrapper, and
+# clear bash's command hash so the lookup re-resolves.
 export PATH="/home/viber/bin:$PATH"
 hash -r 2>/dev/null || true
 
-# Auto-start vibe on first interactive shell (now resolves to the wrapper).
 if [[ $SHLVL -eq 1 && -z "${SECURE_VIBE_EXPLICIT_CMD:-}" ]]; then
   vibe || true
   echo ""

--- a/src/assets/vibe-wrapper.sh
+++ b/src/assets/vibe-wrapper.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-# --yolo approves all tool calls without prompting: the container is the sandbox.
 exec /home/viber/.local/bin/vibe \
   --yolo \
   "$@"

--- a/src/constants/flags.ts
+++ b/src/constants/flags.ts
@@ -1,11 +1,7 @@
 import type { ProviderId } from "../types"
 import { VALID_SAVE_MODES, VALID_RUNTIMES } from "./runtime"
 
-/**
- * Single source of truth for the CLI flag surface. Consumed by BOTH the argument
- * parser (src/utils/args.ts) and the dynamic completion handler (src/utils/completion.ts),
- * so adding a flag here updates parsing AND tab-completion at once — no drift.
- */
+/** Single source of truth for the CLI flag surface: drives both parsing and tab-completion. */
 
 /** A boolean flag carries no value; its presence sets the corresponding ParsedArgs field. */
 export interface BooleanFlag {
@@ -50,10 +46,7 @@ export const PROVIDER_FLAGS: Record<string, ProviderId> = {
   "--miaou": "vibe"
 }
 
-/**
- * Provider flags surfaced by tab-completion. Only "claude", "antigravity", "ccr", "codex", and
- * "vibe" have runners today (the rest are reserved), so we don't offer users non-working options.
- */
+/** Provider flags surfaced by tab-completion — only those with a runner today. */
 export const COMPLETABLE_PROVIDER_FLAGS: readonly string[] = [
   "--claude", "--antigravity", "--agy", "--ccr", "--claude-code-router", "--codex", "--gpt",
   "--vibe", "--lechat", "--mistral", "--miaou"

--- a/src/constants/providers/antigravity.ts
+++ b/src/constants/providers/antigravity.ts
@@ -4,10 +4,7 @@ import { join } from "path"
 /** Host's ~/.gemini — agy settings/state. Mounted read-only, mirrored in. */
 export const GEMINI_DIR = join(homedir(), ".gemini")
 
-/**
- * agy's token file when it runs in a container (it detects /.dockerenv and skips the
- * keyring). The entrypoint writes the host token here so agy starts logged in.
- */
+/** Where agy reads its token in a container, having detected /.dockerenv and skipped the keyring. */
 export const AGY_TOKEN_REL_PATH = "antigravity-cli/antigravity-oauth-token"
 
 /** Same file on a Linux host that already ran agy headless — read directly if present. */

--- a/src/constants/runtime.ts
+++ b/src/constants/runtime.ts
@@ -7,10 +7,7 @@ export const VALID_SAVE_MODES: SaveMode[] = ["zip", "copy", "no"]
 /** Valid CLI values for --runtime. Mirrors the Runtime type as a value so the parser and completion can share it. */
 export const VALID_RUNTIMES: Runtime[] = ["docker", "podman"]
 
-/**
- * Exit codes that indicate a normal user-initiated termination (e.g. typing exit,
- * pressing Ctrl+C). These are mapped to 0 so Bun doesn't print a script error.
- */
+/** User-initiated terminations (exit, Ctrl+C), mapped to 0 so Bun prints no script error. */
 export const CLEAN_EXIT_CODES = new Set<number>([
   130, // SIGINT (Ctrl+C / shell exit)
   143 // SIGTERM

--- a/src/entrypoints/antigravity.ts
+++ b/src/entrypoints/antigravity.ts
@@ -1,43 +1,13 @@
-/**
- * Antigravity container entrypoint (PID 1).
- *
- * Runs every time the Antigravity provider container starts. Responsibilities:
- *   1. Seed the named brew volume from /opt/linuxbrew-seed on first run.
- *   2. Mirror the read-only ~/.gemini-host mount into a writable copy, then write
- *      the host agy token ($AGY_OAUTH_TOKEN) to the file agy reads in a container.
- *   3. Whitelist the workspace by adding it to "trustedWorkspaces" in
- *      ~/.gemini/antigravity-cli/settings.json so agy skips its "Do you trust
- *      this folder?" dialog (--dangerously-skip-permissions only covers tool
- *      actions, not folder trust). Merged so host entries survive.
- *   4. Inject the sandbox prompt into ~/.gemini/GEMINI.md (agy has no
- *      --append-system-prompt flag; the global GEMINI.md is prepended to every
- *      prompt). Marker-guarded so it's idempotent and keeps any existing context.
- *   5. Apply host git identity from $GIT_USER_NAME / $GIT_USER_EMAIL.
- *   6. Ignore SIGINT at PID 1 so Ctrl+C kills only the foreground job (agy)
- *      without exiting the shell.
- *   7. Spawn either the explicit command (and set $SECURE_VIBE_EXPLICIT_CMD=1
- *      so the bashrc auto-start guard skips agy) or an interactive bash.
- *
- * The COPY directive in docker/antigravity.dockerfile maps this file to the
- * provider-agnostic in-container path /home/viber/entrypoint.ts.
- */
-
 import { mkdir, writeFile, readFile, access } from "fs/promises"
 import { $ } from "bun"
 
-// ── Seed linuxbrew volume on first run ────────────────────────────────────────
-// The named volume at /home/linuxbrew starts empty; copy from the seed baked
-// into the image. Subsequent runs skip this entirely.
 const brewReady = await access("/home/linuxbrew/.linuxbrew").then(() => true).catch(() => false)
 if(!brewReady) {
   console.info("  [entrypoint] First run: seeding brew volume from image (this may take a minute)…")
   await $`cp -a /opt/linuxbrew-seed/. /home/linuxbrew/`.nothrow()
   console.info("  [entrypoint] Brew volume ready.")
 } else {
-  // The brew volume persists and stores real numeric UID ownership. If it was
-  // seeded by an image with a different UID (e.g. an older build), brew can't
-  // write it and there's no root at runtime to repair it. Detect that early and
-  // tell the user exactly how to recover instead of letting brew fail cryptically.
+  // The volume stores numeric UID ownership and there is no root at runtime to repair it.
   const { exitCode } = await $`test -w /home/linuxbrew/.linuxbrew/Cellar`.nothrow().quiet()
   if(exitCode !== 0) {
     console.warn("  [entrypoint] ⚠ The brew volume is owned by a different UID — brew will fail to install packages.")
@@ -48,8 +18,7 @@ if(!brewReady) {
 const HOME_DIR = "/home/viber"
 const GEMINI_DIR = `${HOME_DIR}/.gemini`
 
-// Copy a read-only host mount into a writable copy (agy refreshes its own state).
-// dotglob so hidden files come along; the host stays untouched.
+/** Copies a read-only host mount into a writable copy; the host stays untouched. */
 async function mirror(hostDir: string, targetDir: string): Promise<void> {
   const hostExists = await access(hostDir).then(() => true).catch(() => false)
   if(!hostExists) return
@@ -63,8 +32,7 @@ async function mirror(hostDir: string, targetDir: string): Promise<void> {
 
 await mirror(`${HOME_DIR}/.gemini-host`, GEMINI_DIR)
 
-// Write the host's agy token to the file agy reads in container mode (it skips the
-// keyring when it detects /.dockerenv), so the session starts logged in.
+// agy skips the keyring when it detects /.dockerenv and reads this file instead.
 const agyToken = process.env.AGY_OAUTH_TOKEN
 if(agyToken) {
   const tokenDir = `${GEMINI_DIR}/antigravity-cli`
@@ -72,11 +40,8 @@ if(agyToken) {
   await writeFile(`${tokenDir}/antigravity-oauth-token`, agyToken, { mode: 0o600 })
 }
 
-// Whitelist the workspace so agy skips its "Do you trust this folder?" dialog
-// (the wrapper's --dangerously-skip-permissions only auto-approves tool actions,
-// not folder trust). agy stores trust as a plain array of absolute paths under
-// "trustedWorkspaces" in ~/.gemini/antigravity-cli/settings.json. Merge into any
-// mirrored host settings so the user's other trusted paths survive.
+// Folder trust is separate from tool approvals, so --dangerously-skip-permissions does not
+// cover it. Merged into any mirrored host settings so other trusted paths survive.
 const APP_DIR = "/home/viber/app"
 const agySettingsDir = `${GEMINI_DIR}/antigravity-cli`
 const agySettingsPath = `${agySettingsDir}/settings.json`
@@ -99,8 +64,7 @@ if(!trustedWorkspaces.includes(APP_DIR)) {
   await writeFile(agySettingsPath, JSON.stringify(agySettings, null, 2), { mode: 0o600 })
 }
 
-// agy has no --append-system-prompt flag, so the sandbox prompt goes into the
-// global ~/.gemini/GEMINI.md. Marker-guarded so it's idempotent and keeps existing context.
+// No --append-system-prompt flag, so the prompt goes into the global instructions file.
 const SANDBOX_PROMPT_FILE = `${HOME_DIR}/.secure-vibe-sandbox.md`
 const START_MARKER = "<!-- secure-vibe sandbox (start) -->"
 const END_MARKER = "<!-- secure-vibe sandbox (end) -->"
@@ -111,7 +75,6 @@ if(sandboxPrompt) {
   const geminiMdPath = `${GEMINI_DIR}/GEMINI.md`
   const existing = await readFile(geminiMdPath, "utf-8").catch(() => "")
 
-  // Strip any previous secure-vibe block, then append a fresh one.
   let base = existing
   const startIdx = base.indexOf(START_MARKER)
   if(startIdx !== -1) {
@@ -124,7 +87,6 @@ if(sandboxPrompt) {
   await writeFile(geminiMdPath, merged)
 }
 
-// Apply host git identity so commits made inside the container are attributed correctly.
 const gitUserName = process.env.GIT_USER_NAME
 const gitUserEmail = process.env.GIT_USER_EMAIL
 if(gitUserName) {
@@ -134,9 +96,7 @@ if(gitUserEmail) {
   await $`git config --global user.email ${gitUserEmail}`.quiet().nothrow()
 }
 
-// Ignore SIGINT at the bun (PID 1) level so ctrl+c inside the container
-// only reaches bash's job control, which kills the foreground job (agy)
-// without terminating the shell itself.
+// Ignored at PID 1 so ctrl+c reaches bash's job control and kills only the foreground job.
 process.on("SIGINT", () => {})
 
 const cmd = process.argv.slice(2)

--- a/src/entrypoints/ccr.ts
+++ b/src/entrypoints/ccr.ts
@@ -1,55 +1,14 @@
-/**
- * CCR (claude-code-router) container entrypoint (PID 1).
- *
- * Runs every time the CCR provider container starts. Responsibilities:
- *   1. Seed the named brew volume from /opt/linuxbrew-seed on first run.
- *   2. Mirror the read-only ~/.claude-code-router-host mount into a writable
- *      ~/.claude-code-router, skipping CCR's own sqlite state (see below).
- *   3. Normalize that config: pin HOST to loopback, inject a dummy APIKEY when none is
- *      set, and read Router.default/background — which CCR 3.x ignores — to derive the
- *      ANTHROPIC_* model env Claude Code actually honours.
- *   4. Start `ccr serve` as a sidecar gateway and wait for it to answer /health.
- *   5. Pre-accept Claude Code's first-run flags (onboarding, trust, bypass) in
- *      ~/.claude.json so it launches straight into a session with no wizard — done
- *      unconditionally since CCR users usually have no Anthropic account. No OAuth is
- *      injected (it could make Claude bypass CCR and hit Anthropic directly).
- *   6. Apply host git identity from $GIT_USER_NAME / $GIT_USER_EMAIL.
- *   7. Ignore SIGINT at PID 1 so Ctrl+C kills only the foreground job without exiting the
- *      shell; tear the gateway down on SIGTERM and on normal exit.
- *   8. Spawn either the explicit command (and set $SECURE_VIBE_EXPLICIT_CMD=1 so the
- *      bashrc auto-start guard skips ccr) or an interactive bash.
- *
- * CCR 3.x dropped `ccr code`, so CCR no longer launches Claude Code — it is a plain
- * Anthropic-compatible gateway on 127.0.0.1 and the /home/viber/bin/claude wrapper points
- * at it. That wrapper is the single source for the bypass flag and the sandbox prompt.
- *
- * CRITICAL INVARIANT: CCR imports config.json ONLY when its sqlite store has no config row,
- * then deletes the JSON. Three things depend on the container starting with no sqlite —
- * the mounted config being read at all, `$VAR` interpolation (legacy-import path only, which
- * is what makes the runner's least-privilege env forwarding work), and host edits taking
- * effect on the next run. Hence the mirror exclusions and the purge below.
- *
- * The COPY directive in docker/ccr.dockerfile maps this file to the provider-agnostic
- * in-container path /home/viber/entrypoint.ts.
- */
-
 import { mkdir, writeFile, readFile, access } from "fs/promises"
 import { openSync } from "fs"
 import { $ } from "bun"
 
-// ── Seed linuxbrew volume on first run ────────────────────────────────────────
-// The named volume at /home/linuxbrew starts empty; copy from the seed baked
-// into the image. Subsequent runs skip this entirely.
 const brewReady = await access("/home/linuxbrew/.linuxbrew").then(() => true).catch(() => false)
 if(!brewReady) {
   console.info("  [entrypoint] First run: seeding brew volume from image (this may take a minute)…")
   await $`cp -a /opt/linuxbrew-seed/. /home/linuxbrew/`.nothrow()
   console.info("  [entrypoint] Brew volume ready.")
 } else {
-  // The brew volume persists and stores real numeric UID ownership. If it was
-  // seeded by an image with a different UID (e.g. an older build), brew can't
-  // write it and there's no root at runtime to repair it. Detect that early and
-  // tell the user exactly how to recover instead of letting brew fail cryptically.
+  // The volume stores numeric UID ownership and there is no root at runtime to repair it.
   const { exitCode } = await $`test -w /home/linuxbrew/.linuxbrew/Cellar`.nothrow().quiet()
   if(exitCode !== 0) {
     console.warn("  [entrypoint] ⚠ The brew volume is owned by a different UID — brew will fail to install packages.")
@@ -61,8 +20,6 @@ const HOME_DIR = "/home/viber"
 const CCR_DIR = `${HOME_DIR}/.claude-code-router`
 const CCR_HOST_DIR = `${HOME_DIR}/.claude-code-router-host`
 const CCR_CONFIG_PATH = `${CCR_DIR}/config.json`
-// Image-baked starter (src/assets/ccr-starter-config.json, COPYed in by the Dockerfile). Same
-// single source the host runner imports, so the host and fallback scaffolds never drift.
 const CCR_STARTER_CONFIG_PATH = `${HOME_DIR}/.ccr-starter-config.json`
 const CCR_ENV_PATH = `${HOME_DIR}/.secure-vibe-ccr.env`
 const CCR_LOG_PATH = `${HOME_DIR}/.ccr-serve.log`
@@ -70,9 +27,7 @@ const CCR_BIN = `${HOME_DIR}/bin/ccr-default`
 const DEFAULT_PORT = 3456
 const DEFAULT_APIKEY = "secure-vibe"
 
-// CCR's own state, never mirrored from the host: sqlite would suppress the config.json
-// import (see CRITICAL INVARIANT above) and service.json describes a service that isn't
-// running in this container.
+// CCR's own state, never mirrored: it would suppress the config.json import (see below).
 const CCR_STATE_ENTRIES = [
   "config.sqlite",
   "config.sqlite-wal",
@@ -98,8 +53,8 @@ async function mirror(hostDir: string, targetDir: string): Promise<void> {
 await mkdir(CCR_DIR, { recursive: true })
 await mirror(CCR_HOST_DIR, CCR_DIR)
 
-// Belt and braces: guarantee the JSON import path runs even if the mirror leaked state or a
-// previous layer left something behind. Cheap, and the whole design rests on it.
+// CCR imports config.json only when its sqlite store is empty, so the mounted config, `$VAR`
+// interpolation and host edits all depend on the container starting without one.
 await $`rm -rf ${CCR_DIR}/config.sqlite ${CCR_DIR}/config.sqlite-wal ${CCR_DIR}/config.sqlite-shm ${CCR_DIR}/app-data`.nothrow().quiet()
 
 /** What the container needs from the CCR config once CCR has consumed (and deleted) it. */
@@ -110,10 +65,7 @@ interface CcrConfigSummary {
   backgroundModel: string | null
 }
 
-/**
- * Converts a v2 `provider,model` selector to the 3.x `Provider/model` form, leaving
- * already-migrated values untouched.
- */
+/** Converts a v2 `provider,model` selector to the 3.x `Provider/model` form. */
 function toModelSelector(value: unknown): string | null {
   if(typeof value !== "string" || value.length === 0) return null
   const separator = value.indexOf(",")
@@ -137,10 +89,7 @@ function providerModelSelectors(config: Record<string, unknown>): string[] {
   return selectors
 }
 
-/**
- * Normalizes the mirrored config in place and returns what the rest of the entrypoint needs.
- * Must be called before `ccr serve`, which deletes config.json after importing it.
- */
+/** Normalizes the mirrored config in place; must run before `ccr serve` deletes it. */
 async function normalizeCcrConfig(): Promise<CcrConfigSummary> {
   const fallback: CcrConfigSummary = { port: DEFAULT_PORT, apiKey: DEFAULT_APIKEY, defaultModel: null, backgroundModel: null }
 
@@ -148,9 +97,7 @@ async function normalizeCcrConfig(): Promise<CcrConfigSummary> {
   try {
     raw = await readFile(CCR_CONFIG_PATH, "utf-8")
   } catch(readError: unknown) {
-    // No config mounted — scaffold the image-baked starter into an EPHEMERAL in-container
-    // copy (lost on exit). The host runner normally scaffolds a persistent config before
-    // spawn, so reaching here is the fallback path.
+    // Fallback path: the host runner normally scaffolds a persistent config before spawn.
     try {
       raw = await readFile(CCR_STARTER_CONFIG_PATH, "utf-8")
       await writeFile(CCR_CONFIG_PATH, raw, { mode: 0o600 })
@@ -171,17 +118,12 @@ async function normalizeCcrConfig(): Promise<CcrConfigSummary> {
     return fallback
   }
 
-  // Pin HOST to loopback unconditionally. The container publishes no ports so this can't be
-  // reached from the host regardless, but it keeps the "never bind wide" guarantee.
   config.HOST = "127.0.0.1"
-  // CCR 3.x rejects every gateway request without a key, and Claude Code needs a non-empty
-  // token to consider itself authenticated. Only inject when absent, so a real key is kept.
+  // CCR rejects keyless requests and Claude Code needs a token, so inject one when absent.
   const apiKey = typeof config.APIKEY === "string" && config.APIKEY.length > 0 ? config.APIKEY : DEFAULT_APIKEY
   config.APIKEY = apiKey
 
-  // `ccr serve` otherwise takes over ~/.claude/settings.json for its Agent Profiles, writing an
-  // apiKeyHelper that fights the ANTHROPIC_AUTH_TOKEN we set — Claude Code warns "auth may not
-  // work as expected". We never launch profiles, so turn the whole mechanism off.
+  // Otherwise `ccr serve` writes an apiKeyHelper that fights our ANTHROPIC_AUTH_TOKEN.
   const profile = typeof config.profile === "object" && config.profile !== null
     ? config.profile as Record<string, unknown>
     : {}
@@ -194,8 +136,7 @@ async function normalizeCcrConfig(): Promise<CcrConfigSummary> {
   const defaultModel = toModelSelector(router.default)
   const backgroundModel = toModelSelector(router.background) ?? defaultModel
 
-  // A Router slot naming a model no provider lists is only caught by CCR at request time, as an
-  // opaque 400 mid-session. Say so up front instead.
+  // CCR only catches an unserved Router slot at request time, as an opaque 400 mid-session.
   const available = providerModelSelectors(config)
   const unserved = [...new Set([defaultModel, backgroundModel].filter(
     (selector): selector is string => selector !== null && available.length > 0 && !available.includes(selector)
@@ -214,9 +155,7 @@ async function normalizeCcrConfig(): Promise<CcrConfigSummary> {
 
 const ccrConfig = await normalizeCcrConfig()
 
-// ── Gateway sidecar ───────────────────────────────────────────────────────────
-// Output goes to a log file, never to the TTY: `ccr serve` prints a management-server
-// banner (and per-request lines) that would corrupt Claude Code's TUI rendering.
+// Logged to a file, never the TTY: `ccr serve`'s output would corrupt Claude Code's TUI.
 const gatewayLogFd = openSync(CCR_LOG_PATH, "a")
 const gateway = Bun.spawn([CCR_BIN, "serve", "--no-open"], {
   stdin: "ignore",
@@ -229,13 +168,7 @@ type GatewayOutcome = "ready" | "exited" | "failed" | "timeout"
 /** CCR logs this and then never binds the gateway port, so waiting the full timeout is pointless. */
 const FATAL_LOG_MARKER = "No available models"
 
-/**
- * Polls the gateway's unauthenticated /health until it can actually route, the child dies, or
- * we time out. Probe failures are expected while it boots, so the last one is only reported if
- * we give up. Note /health answers 200 with {"status":"starting"} well before the core gateway
- * is up, so status is checked too — matching on "not starting" rather than a specific ready
- * value keeps this from hanging if CCR renames that state.
- */
+/** Polls /health, which answers 200 while still "starting", until the gateway can route. */
 let lastProbeError: unknown = null
 async function waitForGateway(port: number, timeoutMs: number): Promise<GatewayOutcome> {
   const deadline = Date.now() + timeoutMs
@@ -262,10 +195,8 @@ if(gatewayOutcome === "ready") {
   const routed = ccrConfig.defaultModel ? ` (model: ${ccrConfig.defaultModel})` : ""
   console.info(`  [entrypoint] CCR gateway ready on 127.0.0.1:${ccrConfig.port}${routed}.`)
 } else {
-  // Non-fatal on purpose, matching the brew-volume failure above: drop the user into the
-  // shell so they can read the log and fix their config instead of losing the container.
   // The log is classified first: CCR keeps its management server alive after refusing to bind
-  // the gateway, so this path is reached by timeout as often as by the child exiting.
+  // the gateway, so this is reached by timeout as often as by the child exiting.
   const log = await readFile(CCR_LOG_PATH, "utf-8").catch(() => "")
   console.warn("  [entrypoint] ⚠ The CCR gateway did not start — Claude Code will not be able to reach a model.")
   if(log.includes(FATAL_LOG_MARKER)) {
@@ -281,17 +212,13 @@ if(gatewayOutcome === "ready") {
   }
 }
 
-// Endpoint + token for every shell in this container. The wrappers and .bashrc source this
-// file, so `docker exec -it <container> claude` works even though it inherits nothing.
+// Sourced by the wrappers and .bashrc, so `docker exec -it <container> claude` works too.
 function shellQuote(value: string): string {
   return `'${value.replace(/'/g, "'\\''")}'`
 }
 
-// BASE_URL/AUTH_TOKEN are hard-set — a stale value means talking to Anthropic directly, which
-// would defeat the container. The model vars use := so `ANTHROPIC_MODEL=x claude` still wins.
-// Without gateway model discovery Claude Code rejects any model id it doesn't recognise —
-// "There's an issue with the selected model … it may not exist" — before sending a request.
-// The gateway answers both /models and /v1/models, which is what discovery needs.
+// The model vars use := so `ANTHROPIC_MODEL=x claude` still wins. Without gateway model
+// discovery Claude Code rejects unrecognised model ids client-side, before any request.
 const envFileLines = [
   `export ANTHROPIC_BASE_URL=${shellQuote(`http://127.0.0.1:${ccrConfig.port}`)}`,
   `export ANTHROPIC_AUTH_TOKEN=${shellQuote(ccrConfig.apiKey)}`,
@@ -301,8 +228,7 @@ const modelDefaults: Record<string, string | null> = {
   ANTHROPIC_MODEL: ccrConfig.defaultModel,
   ANTHROPIC_DEFAULT_OPUS_MODEL: ccrConfig.defaultModel,
   ANTHROPIC_DEFAULT_SONNET_MODEL: ccrConfig.defaultModel,
-  // Claude Code sends Haiku for titles, summaries and file suggestions; without a mapping
-  // those calls ask the gateway for a model no provider serves and fail mid-session.
+  // Claude Code sends Haiku for titles and summaries; unmapped, those calls fail mid-session.
   ANTHROPIC_DEFAULT_HAIKU_MODEL: ccrConfig.backgroundModel
 }
 for(const [name, value] of Object.entries(modelDefaults)) {
@@ -319,13 +245,8 @@ for(const [name, value] of Object.entries(modelDefaults)) {
   if(value && !process.env[name]) gatewayEnv[name] = value
 }
 
-// Pre-accept Claude Code's first-run flags so it launches straight into a session
-// instead of the onboarding wizard (theme picker, trust-folder, bypass warning).
-// CCR users typically have NO Anthropic account — CCR supplies the endpoint and token —
-// so we seed these UNCONDITIONALLY (the claude provider only does it alongside creds).
-//
-// We deliberately do NOT inject Claude.ai OAuth here: a real subscription token can make
-// Claude Code talk to Anthropic directly and ignore CCR's local endpoint, defeating routing.
+// No Claude.ai OAuth is injected: a real subscription token could make Claude Code talk to
+// Anthropic directly and ignore CCR's local endpoint.
 const CLAUDE_DIR = `${HOME_DIR}/.claude`
 const CLAUDE_JSON = `${HOME_DIR}/.claude.json`
 const CLAUDE_SETTINGS = `${CLAUDE_DIR}/settings.json`
@@ -341,7 +262,7 @@ try {
 claudeJson.hasCompletedOnboarding = true
 if(!claudeJson.theme) claudeJson.theme = "dark"
 
-// Pre-approve the token CCR expects so Claude doesn't prompt "use this custom API key?".
+// Pre-approved so Claude doesn't prompt "use this custom API key?".
 if(!claudeJson.customApiKeyResponses) {
   claudeJson.customApiKeyResponses = { approved: [ccrConfig.apiKey], rejected: [] }
 }
@@ -354,8 +275,7 @@ projects[APP_DIR].hasTrustDialogAccepted = true
 
 await writeFile(CLAUDE_JSON, JSON.stringify(claudeJson), { mode: 0o600 })
 
-// Suppress the bypass-permissions warning dialog (modern Claude Code gates it on this
-// settings key, not the legacy ~/.claude.json bypassPermissionsModeAccepted flag).
+// Suppresses the bypass-permissions dialog, which is gated on this key, not the legacy flag.
 let claudeSettings: Record<string, unknown> = {}
 try {
   claudeSettings = JSON.parse(await readFile(CLAUDE_SETTINGS, "utf-8"))
@@ -363,12 +283,10 @@ try {
   claudeSettings = {}
 }
 claudeSettings.skipDangerousModePermissionPrompt = true
-// Defensive: if any CCR version still installs its profile apiKeyHelper, drop it — it and our
-// ANTHROPIC_AUTH_TOKEN are mutually exclusive as far as Claude Code is concerned.
+// A stray profile apiKeyHelper and our ANTHROPIC_AUTH_TOKEN are mutually exclusive.
 delete claudeSettings.apiKeyHelper
 await writeFile(CLAUDE_SETTINGS, JSON.stringify(claudeSettings, null, 2), { mode: 0o600 })
 
-// Apply host git identity so commits made inside the container are attributed correctly.
 const gitUserName = process.env.GIT_USER_NAME
 const gitUserEmail = process.env.GIT_USER_EMAIL
 if(gitUserName) {
@@ -378,14 +296,9 @@ if(gitUserEmail) {
   await $`git config --global user.email ${gitUserEmail}`.quiet().nothrow()
 }
 
-// Ignore SIGINT at the bun (PID 1) level so ctrl+c inside the container
-// only reaches bash's job control, which kills the foreground job (claude)
-// without terminating the shell itself. The gateway is not in bash's foreground
-// process group, so it survives too.
+// Ignored at PID 1 so ctrl+c reaches bash's job control and kills only the foreground job.
 process.on("SIGINT", () => {})
-// `ccr serve` stops listening on SIGTERM but does not exit promptly, and it owns a core-gateway
-// grandchild bun can't signal directly. Exiting PID 1 right after is what actually tears the
-// container (and both processes) down; the signal is a courtesy so CCR can flush first.
+// `ccr serve` ignores SIGTERM in practice, so exiting PID 1 is what tears the container down.
 process.on("SIGTERM", () => {
   gateway.kill()
   process.exit(143)

--- a/src/entrypoints/claude.ts
+++ b/src/entrypoints/claude.ts
@@ -1,39 +1,13 @@
-/**
- * Claude container entrypoint (PID 1).
- *
- * Runs every time the Claude provider container starts. Responsibilities:
- *   1. Seed the named brew volume from /opt/linuxbrew-seed on first run.
- *   2. Mirror the read-only ~/.claude-host mount into a writable ~/.claude.
- *   3. Materialise credentials from $CLAUDE_CREDENTIALS (set by the host
- *      runClaudeContainer) into ~/.claude.json and ~/.claude/.credentials.json,
- *      pre-toggling the onboarding/permission flags so Claude doesn't prompt.
- *   4. Apply host git identity from $GIT_USER_NAME / $GIT_USER_EMAIL.
- *   5. Ignore SIGINT at PID 1 so Ctrl+C kills only the foreground job
- *      (claude) without exiting the shell.
- *   6. Spawn either the explicit command (and set $SECURE_VIBE_EXPLICIT_CMD=1
- *      so the bashrc auto-start guard skips Claude) or an interactive bash.
- *
- * The COPY directive in docker/claude.dockerfile maps this file to the
- * provider-agnostic in-container path /home/viber/entrypoint.ts so future
- * provider Dockerfiles can swap their own entrypoint behind the same path.
- */
-
 import { mkdir, writeFile, readFile, access, rm } from "fs/promises"
 import { $ } from "bun"
 
-// ── Seed linuxbrew volume on first run ────────────────────────────────────────
-// The named volume at /home/linuxbrew starts empty; copy from the seed baked
-// into the image. Subsequent runs skip this entirely.
 const brewReady = await access("/home/linuxbrew/.linuxbrew").then(() => true).catch(() => false)
 if(!brewReady) {
   console.info("  [entrypoint] First run: seeding brew volume from image (this may take a minute)…")
   await $`cp -a /opt/linuxbrew-seed/. /home/linuxbrew/`.nothrow()
   console.info("  [entrypoint] Brew volume ready.")
 } else {
-  // The brew volume persists and stores real numeric UID ownership. If it was
-  // seeded by an image with a different UID (e.g. an older build), brew can't
-  // write it and there's no root at runtime to repair it. Detect that early and
-  // tell the user exactly how to recover instead of letting brew fail cryptically.
+  // The volume stores numeric UID ownership and there is no root at runtime to repair it.
   const { exitCode } = await $`test -w /home/linuxbrew/.linuxbrew/Cellar`.nothrow().quiet()
   if(exitCode !== 0) {
     console.warn("  [entrypoint] ⚠ The brew volume is owned by a different UID — brew will fail to install packages.")
@@ -48,8 +22,6 @@ const HOME_DIR = "/home/viber"
 
 await mkdir(CLAUDE_DIR, { recursive: true })
 
-// Copy contents of .claude-host into .claude.
-// Uses bash with dotglob so hidden files are included alongside regular ones.
 const hostDirExists = await access(CLAUDE_HOST_DIR).then(() => true).catch(() => false)
 if(hostDirExists) {
   const cpProc = Bun.spawn(
@@ -59,10 +31,6 @@ if(hostDirExists) {
   await cpProc.exited
 }
 
-// Inject credentials from the env var set by runClaudeContainer.
-// CLAUDE_CREDENTIALS contains a merged JSON with claudeAiOauth + onboarding metadata.
-// Write the full object to ~/.claude.json (Claude 2.1.63+ primary location) and
-// write just the auth fields to ~/.claude/.credentials.json (older Claude fallback).
 const credentials = process.env.CLAUDE_CREDENTIALS
 if(credentials) {
   let parsed: Record<string, unknown>
@@ -73,8 +41,7 @@ if(credentials) {
     parsed = {}
   }
 
-  // ~/.claude.json — full merged config. Keychain creds carry only auth tokens, not UI state,
-  // so set onboarding here; the bypass warning is pre-accepted in settings.json below.
+  // Keychain creds carry auth tokens but no UI state, so the onboarding flags are set here.
   if(!parsed.hasCompletedOnboarding) parsed.hasCompletedOnboarding = true
 
   const APP_DIR = "/home/viber/app"
@@ -85,7 +52,7 @@ if(credentials) {
 
   await writeFile(`${HOME_DIR}/.claude.json`, JSON.stringify(parsed), { mode: 0o600 })
 
-  // ~/.claude/.credentials.json — auth fields only (legacy fallback)
+  // Legacy fallback location, auth fields only.
   const authOnly = JSON.stringify({
     claudeAiOauth: parsed.claudeAiOauth,
     organizationUuid: parsed.organizationUuid
@@ -96,8 +63,7 @@ if(credentials) {
   console.warn("  [entrypoint] CLAUDE_CREDENTIALS not set — Claude will prompt for authentication.")
 }
 
-// Suppress the bypass-permissions warning dialog (modern Claude Code gates it on this
-// settings key, not the legacy ~/.claude.json bypassPermissionsModeAccepted flag).
+// Suppresses the bypass-permissions dialog, which is gated on this key, not the legacy flag.
 let claudeSettings: Record<string, unknown> = {}
 try {
   claudeSettings = JSON.parse(await readFile(CLAUDE_SETTINGS, "utf-8")) as Record<string, unknown>
@@ -107,7 +73,6 @@ try {
 claudeSettings.skipDangerousModePermissionPrompt = true
 await writeFile(CLAUDE_SETTINGS, JSON.stringify(claudeSettings, null, 2), { mode: 0o600 })
 
-// Apply host git identity so commits made inside the container are attributed correctly.
 const gitUserName = process.env.GIT_USER_NAME
 const gitUserEmail = process.env.GIT_USER_EMAIL
 if(gitUserName) {
@@ -117,9 +82,7 @@ if(gitUserEmail) {
   await $`git config --global user.email ${gitUserEmail}`.quiet().nothrow()
 }
 
-// Ignore SIGINT at the bun (PID 1) level so ctrl+c inside the container
-// only reaches bash's job control, which kills the foreground job (claude)
-// without terminating the shell itself.
+// Ignored at PID 1 so ctrl+c reaches bash's job control and kills only the foreground job.
 process.on("SIGINT", () => {})
 
 const cmd = process.argv.slice(2)

--- a/src/entrypoints/codex.ts
+++ b/src/entrypoints/codex.ts
@@ -1,46 +1,13 @@
-/**
- * Codex container entrypoint (PID 1).
- *
- * Runs every time the Codex provider container starts. Responsibilities:
- *   1. Seed the named brew volume from /opt/linuxbrew-seed on first run.
- *   2. Mirror the read-only ~/.codex-host mount into a writable copy, then write
- *      the host auth ($CODEX_CREDENTIALS) to ~/.codex/auth.json so the session
- *      starts logged in (codex refreshes tokens against its own copy; the host
- *      file is never touched).
- *   3. Whitelist the workspace by adding a [projects."/home/viber/app"] table
- *      with trust_level = "trusted" to ~/.codex/config.toml so codex skips its
- *      "Do you trust this folder?" dialog (--dangerously-bypass-approvals-and-sandbox
- *      only covers approvals/sandboxing, not folder trust). Appended so any
- *      mirrored host config survives.
- *   4. Inject the sandbox prompt into ~/.codex/AGENTS.md (codex has no
- *      --append-system-prompt flag; the global AGENTS.md is prepended to every
- *      session). Marker-guarded so it's idempotent and keeps any existing context.
- *   5. Apply host git identity from $GIT_USER_NAME / $GIT_USER_EMAIL.
- *   6. Ignore SIGINT at PID 1 so Ctrl+C kills only the foreground job (codex)
- *      without exiting the shell.
- *   7. Spawn either the explicit command (and set $SECURE_VIBE_EXPLICIT_CMD=1
- *      so the bashrc auto-start guard skips codex) or an interactive bash.
- *
- * The COPY directive in docker/codex.dockerfile maps this file to the
- * provider-agnostic in-container path /home/viber/entrypoint.ts.
- */
-
 import { mkdir, writeFile, readFile, access } from "fs/promises"
 import { $ } from "bun"
 
-// ── Seed linuxbrew volume on first run ────────────────────────────────────────
-// The named volume at /home/linuxbrew starts empty; copy from the seed baked
-// into the image. Subsequent runs skip this entirely.
 const brewReady = await access("/home/linuxbrew/.linuxbrew").then(() => true).catch(() => false)
 if(!brewReady) {
   console.info("  [entrypoint] First run: seeding brew volume from image (this may take a minute)…")
   await $`cp -a /opt/linuxbrew-seed/. /home/linuxbrew/`.nothrow()
   console.info("  [entrypoint] Brew volume ready.")
 } else {
-  // The brew volume persists and stores real numeric UID ownership. If it was
-  // seeded by an image with a different UID (e.g. an older build), brew can't
-  // write it and there's no root at runtime to repair it. Detect that early and
-  // tell the user exactly how to recover instead of letting brew fail cryptically.
+  // The volume stores numeric UID ownership and there is no root at runtime to repair it.
   const { exitCode } = await $`test -w /home/linuxbrew/.linuxbrew/Cellar`.nothrow().quiet()
   if(exitCode !== 0) {
     console.warn("  [entrypoint] ⚠ The brew volume is owned by a different UID — brew will fail to install packages.")
@@ -51,8 +18,7 @@ if(!brewReady) {
 const HOME_DIR = "/home/viber"
 const CODEX_DIR = `${HOME_DIR}/.codex`
 
-// Copy a read-only host mount into a writable copy (codex refreshes its own state).
-// dotglob so hidden files come along; the host stays untouched.
+/** Copies a read-only host mount into a writable copy; the host stays untouched. */
 async function mirror(hostDir: string, targetDir: string): Promise<void> {
   const hostExists = await access(hostDir).then(() => true).catch(() => false)
   if(!hostExists) return
@@ -66,9 +32,7 @@ async function mirror(hostDir: string, targetDir: string): Promise<void> {
 
 await mirror(`${HOME_DIR}/.codex-host`, CODEX_DIR)
 
-// Write the host's Codex auth to the file codex reads (plaintext JSON on every
-// platform), so the session starts logged in. Written raw — the host runner
-// already validated it carries tokens or an API key.
+// Written raw: the host runner already validated it carries tokens or an API key.
 const credentials = process.env.CODEX_CREDENTIALS
 if(credentials) {
   await mkdir(CODEX_DIR, { recursive: true })
@@ -77,12 +41,8 @@ if(credentials) {
   console.warn("  [entrypoint] CODEX_CREDENTIALS not set — codex will prompt for authentication.")
 }
 
-// Whitelist the workspace so codex skips its "Do you trust this folder?" dialog
-// (the wrapper's --dangerously-bypass-approvals-and-sandbox only covers approvals
-// and sandboxing, not folder trust). codex stores trust as a per-project table in
-// ~/.codex/config.toml. No TOML parser here: appending a table at EOF is valid
-// TOML, and the substring check keeps it idempotent — a mirrored host config that
-// already mentions the path is left alone.
+// Folder trust is separate from approvals, so the bypass flag does not cover it. No TOML
+// parser here: appending a table at EOF is valid TOML and the substring check is idempotent.
 const APP_DIR = "/home/viber/app"
 const codexConfigPath = `${CODEX_DIR}/config.toml`
 const trustHeader = `[projects."${APP_DIR}"]`
@@ -96,8 +56,7 @@ if(!existingConfig.includes(trustHeader)) {
   await writeFile(codexConfigPath, merged, { mode: 0o600 })
 }
 
-// codex has no --append-system-prompt flag, so the sandbox prompt goes into the
-// global ~/.codex/AGENTS.md. Marker-guarded so it's idempotent and keeps existing context.
+// No --append-system-prompt flag, so the prompt goes into the global instructions file.
 const SANDBOX_PROMPT_FILE = `${HOME_DIR}/.secure-vibe-sandbox.md`
 const START_MARKER = "<!-- secure-vibe sandbox (start) -->"
 const END_MARKER = "<!-- secure-vibe sandbox (end) -->"
@@ -108,7 +67,6 @@ if(sandboxPrompt) {
   const agentsMdPath = `${CODEX_DIR}/AGENTS.md`
   const existing = await readFile(agentsMdPath, "utf-8").catch(() => "")
 
-  // Strip any previous secure-vibe block, then append a fresh one.
   let base = existing
   const startIdx = base.indexOf(START_MARKER)
   if(startIdx !== -1) {
@@ -121,7 +79,6 @@ if(sandboxPrompt) {
   await writeFile(agentsMdPath, merged)
 }
 
-// Apply host git identity so commits made inside the container are attributed correctly.
 const gitUserName = process.env.GIT_USER_NAME
 const gitUserEmail = process.env.GIT_USER_EMAIL
 if(gitUserName) {
@@ -131,9 +88,7 @@ if(gitUserEmail) {
   await $`git config --global user.email ${gitUserEmail}`.quiet().nothrow()
 }
 
-// Ignore SIGINT at the bun (PID 1) level so ctrl+c inside the container
-// only reaches bash's job control, which kills the foreground job (codex)
-// without terminating the shell itself.
+// Ignored at PID 1 so ctrl+c reaches bash's job control and kills only the foreground job.
 process.on("SIGINT", () => {})
 
 const cmd = process.argv.slice(2)

--- a/src/entrypoints/vibe.ts
+++ b/src/entrypoints/vibe.ts
@@ -1,46 +1,13 @@
-/**
- * Mistral Vibe container entrypoint (PID 1).
- *
- * Runs every time the Vibe provider container starts. Responsibilities:
- *   1. Seed the named brew volume from /opt/linuxbrew-seed on first run.
- *   2. Mirror the read-only ~/.vibe-host mount into a writable copy (skipping the
- *      potentially huge log tree), then remap host-home paths baked into the mirrored
- *      config.toml ($SECURE_VIBE_HOST_HOME → /home/viber) so vibe doesn't crash
- *      mkdir-ing host paths like session_logging.save_dir. No credential file is
- *      written: the host runner injects $MISTRAL_API_KEY, which vibe reads
- *      process-env-first.
- *   3. Whitelist the workspace by adding "/home/viber/app" to the trusted array in
- *      ~/.vibe/trusted_folders.toml so vibe skips its workspace-trust dialog.
- *   4. Inject the sandbox prompt into ~/.vibe/AGENTS.md (vibe has no
- *      --append-system-prompt flag; the user-level AGENTS.md is loaded into every
- *      session's system prompt). Marker-guarded so it's idempotent and keeps any
- *      existing user instructions.
- *   5. Apply host git identity from $GIT_USER_NAME / $GIT_USER_EMAIL.
- *   6. Ignore SIGINT at PID 1 so Ctrl+C kills only the foreground job (vibe)
- *      without exiting the shell.
- *   7. Spawn either the explicit command (and set $SECURE_VIBE_EXPLICIT_CMD=1
- *      so the bashrc auto-start guard skips vibe) or an interactive bash.
- *
- * The COPY directive in docker/vibe.dockerfile maps this file to the
- * provider-agnostic in-container path /home/viber/entrypoint.ts.
- */
-
 import { mkdir, writeFile, readFile, access } from "fs/promises"
 import { $ } from "bun"
 
-// ── Seed linuxbrew volume on first run ────────────────────────────────────────
-// The named volume at /home/linuxbrew starts empty; copy from the seed baked
-// into the image. Subsequent runs skip this entirely.
 const brewReady = await access("/home/linuxbrew/.linuxbrew").then(() => true).catch(() => false)
 if(!brewReady) {
   console.info("  [entrypoint] First run: seeding brew volume from image (this may take a minute)…")
   await $`cp -a /opt/linuxbrew-seed/. /home/linuxbrew/`.nothrow()
   console.info("  [entrypoint] Brew volume ready.")
 } else {
-  // The brew volume persists and stores real numeric UID ownership. If it was
-  // seeded by an image with a different UID (e.g. an older build), brew can't
-  // write it and there's no root at runtime to repair it. Detect that early and
-  // tell the user exactly how to recover instead of letting brew fail cryptically.
+  // The volume stores numeric UID ownership and there is no root at runtime to repair it.
   const { exitCode } = await $`test -w /home/linuxbrew/.linuxbrew/Cellar`.nothrow().quiet()
   if(exitCode !== 0) {
     console.warn("  [entrypoint] ⚠ The brew volume is owned by a different UID — brew will fail to install packages.")
@@ -51,9 +18,7 @@ if(!brewReady) {
 const HOME_DIR = "/home/viber"
 const VIBE_DIR = `${HOME_DIR}/.vibe`
 
-// Copy a read-only host mount into a writable copy, skipping the log tree (vibe's
-// session logs live in ~/.vibe/logs and can be huge; nothing in-container reads them).
-// chmod guarantees the copy is writable even if host files weren't; the host stays untouched.
+/** Copies a read-only host mount into a writable copy, skipping the (huge, unread) log tree. */
 async function mirror(hostDir: string, targetDir: string): Promise<void> {
   const hostExists = await access(hostDir).then(() => true).catch(() => false)
   if(!hostExists) return
@@ -67,10 +32,8 @@ async function mirror(hostDir: string, targetDir: string): Promise<void> {
 
 await mirror(`${HOME_DIR}/.vibe-host`, VIBE_DIR)
 
-// The mirrored config.toml carries absolute host paths (vibe's setup writes
-// session_logging.save_dir that way) and vibe crashes at startup mkdir-ing them.
-// Remap host-home-prefixed paths to the container home; the lookahead keeps
-// sibling prefixes (e.g. ~/.vibe-backups vs ~/.vibe) intact.
+// vibe crashes at startup mkdir-ing the absolute host paths its own setup baked into
+// config.toml. The lookahead keeps sibling prefixes (~/.vibe-backups vs ~/.vibe) intact.
 const hostHome = process.env.SECURE_VIBE_HOST_HOME
 if(hostHome) {
   const configPath = `${VIBE_DIR}/config.toml`
@@ -82,17 +45,12 @@ if(hostHome) {
   }
 }
 
-// The host runner injects the API key as an env var, which vibe reads directly.
 if(!process.env.MISTRAL_API_KEY) {
   console.warn("  [entrypoint] MISTRAL_API_KEY not set — vibe will prompt for authentication.")
 }
 
-// Whitelist the workspace so vibe skips its workspace-trust dialog. Trust lives in
-// ~/.vibe/trusted_folders.toml as top-level `trusted`/`untrusted` string arrays; vibe
-// checks trusted first, so splicing into it wins even if the host denied the same path.
-// No TOML parser here: splice into an existing `trusted = [` array (a second top-level
-// key would be invalid TOML), else append/create it. Both regexes are ^-anchored so
-// `untrusted = [` never matches, and the idempotency check is scoped to the trusted array.
+// vibe checks `trusted` before `untrusted`, so splicing in wins even if the host denied the
+// path. No TOML parser here; both regexes are ^-anchored so `untrusted = [` never matches.
 const APP_DIR = "/home/viber/app"
 const trustedFoldersPath = `${VIBE_DIR}/trusted_folders.toml`
 const existingTrust = await readFile(trustedFoldersPath, "utf-8").catch(() => "")
@@ -109,9 +67,7 @@ if(!trustedArray.includes(`"${APP_DIR}"`)) {
   await writeFile(trustedFoldersPath, merged, { mode: 0o600 })
 }
 
-// vibe has no --append-system-prompt flag, so the sandbox prompt goes into the
-// user-level ~/.vibe/AGENTS.md (loaded into every session's system prompt).
-// Marker-guarded so it's idempotent and keeps existing context.
+// No --append-system-prompt flag, so the prompt goes into the global instructions file.
 const SANDBOX_PROMPT_FILE = `${HOME_DIR}/.secure-vibe-sandbox.md`
 const START_MARKER = "<!-- secure-vibe sandbox (start) -->"
 const END_MARKER = "<!-- secure-vibe sandbox (end) -->"
@@ -122,7 +78,6 @@ if(sandboxPrompt) {
   const agentsMdPath = `${VIBE_DIR}/AGENTS.md`
   const existing = await readFile(agentsMdPath, "utf-8").catch(() => "")
 
-  // Strip any previous secure-vibe block, then append a fresh one.
   let base = existing
   const startIdx = base.indexOf(START_MARKER)
   if(startIdx !== -1) {
@@ -135,7 +90,6 @@ if(sandboxPrompt) {
   await writeFile(agentsMdPath, merged)
 }
 
-// Apply host git identity so commits made inside the container are attributed correctly.
 const gitUserName = process.env.GIT_USER_NAME
 const gitUserEmail = process.env.GIT_USER_EMAIL
 if(gitUserName) {
@@ -145,9 +99,7 @@ if(gitUserEmail) {
   await $`git config --global user.email ${gitUserEmail}`.quiet().nothrow()
 }
 
-// Ignore SIGINT at the bun (PID 1) level so ctrl+c inside the container
-// only reaches bash's job control, which kills the foreground job (vibe)
-// without terminating the shell itself.
+// Ignored at PID 1 so ctrl+c reaches bash's job control and kills only the foreground job.
 process.on("SIGINT", () => {})
 
 const cmd = process.argv.slice(2)

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,19 +10,14 @@ import { ensureImage } from "./utils/image"
 import { resolveProviderRunner, resolveProviderSpec } from "./providers"
 import { CLEAN_EXIT_CODES } from "./constants"
 
-// ── Dynamic shell completion ────────────────────────────────────────────────
-// The installed shell stub calls `secure-vibe __complete <words…>` on each TAB.
-// Handle it before anything else (no image build, no prompts) and exit.
+// The installed shell stub calls this on each TAB; handle it before anything else.
 if(process.argv.at(2) === "__complete") {
   runCompletion(process.argv.slice(3))
   process.exit(0)
 }
 
-// ── Main ──────────────────────────────────────────────────────────────────────
-
 const args = parseArgs()
 
-// Resolve config: CLI > ENV (null if unset or set to "prompt")
 const dirValue     = args.directory    ?? getEnvConfig("DIRECTORY")
 const saveValue    = args.save         ?? getEnvConfig("SAVE")
 const rtValue      = args.runtime      ?? getEnvConfig("RUNTIME")
@@ -34,16 +29,13 @@ const pullFlag     = args.pull         || getBoolEnv("PULL")
 const localFlag    = args.local        || getBoolEnv("LOCAL")
 const providerId   = args.provider     ?? "claude"
 
-// --local only affects ccr (it adds a host-gateway DNS entry). Warn so a misplaced
-// flag on claude/agy doesn't silently look like it did something.
 if(localFlag && providerId !== "ccr") {
   console.warn(`  ⚠ --local has no effect with the '${providerId}' provider (ccr only); ignoring.`)
 }
 
 console.info("── secure-vibe ──────────────────────────────────────────")
 
-// Resolved early — fails fast with a clear message before we touch the filesystem
-// or a container runtime if the user named an unimplemented provider.
+// Resolved early so an unimplemented provider fails before we touch the filesystem.
 const runProvider = resolveProviderRunner(providerId)
 
 const workDir = await selectDirectory(dirValue)
@@ -59,8 +51,7 @@ if(saveMode !== "no") await saveDirectory(workDir, saveMode)
 const providerSpec = resolveProviderSpec(providerId)
 await ensureImage(runtime, providerSpec, buildFlag, buildNCFlag, pullFlag)
 
-// Resolve files to exclude — done after ensureImage so pre-flight failures
-// (which call process.exit internally) never leave files displaced.
+// After ensureImage, so a pre-flight process.exit never leaves files displaced.
 const excludedFiles = excludeValue
   ? await resolveExcludedFiles(workDir, parseExcludePatterns(excludeValue))
   : []

--- a/src/providers/antigravity/credentials.ts
+++ b/src/providers/antigravity/credentials.ts
@@ -15,13 +15,7 @@ const KEYRING_ACCOUNT = "antigravity"
 // go-keyring base64-encodes stored values with this prefix; agy's token file wants raw JSON.
 const KEYRING_BASE64_PREFIX = "go-keyring-base64:"
 
-/**
- * Resolves the host's agy token to inject; the entrypoint writes it to the file agy
- * reads in container mode so the session starts logged in — same idea as Claude.
- * Order: ANTIGRAVITY_API_KEY → OS keyring (macOS Keychain / Linux Secret Service) →
- * token file (~/.gemini/antigravity-cli/antigravity-oauth-token, used by headless
- * Linux's file storage or a manual drop-in) → warn.
- */
+/** Resolves the agy token to inject: ANTIGRAVITY_API_KEY → OS keyring → token file → warn. */
 export async function resolveAntigravityCredentials(): Promise<AntigravityCredentials> {
   const out: AntigravityCredentials = {}
   if(process.env.ANTIGRAVITY_API_KEY) out.apiKey = process.env.ANTIGRAVITY_API_KEY
@@ -46,10 +40,7 @@ export async function resolveAntigravityCredentials(): Promise<AntigravityCreden
   return out
 }
 
-/**
- * Reads agy's token from the platform keyring and decodes go-keyring's base64 wrapping.
- * Returns null if unavailable — caller falls back to the file.
- */
+/** Reads agy's keyring token, undoing go-keyring's base64 wrapping, or null. */
 async function readOsKeyring(): Promise<string | null> {
   const raw = await readKeyringSecret(KEYRING_SERVICE, KEYRING_ACCOUNT)
   if(!raw) return null

--- a/src/providers/antigravity/run-antigravity-container.ts
+++ b/src/providers/antigravity/run-antigravity-container.ts
@@ -14,11 +14,7 @@ export interface RunAntigravityContainerOptions {
   gitConfig: GitIdentity | null
 }
 
-/**
- * Injects the host agy token (entrypoint.ts writes it to the container's token file
- * so agy starts logged in) and mounts ~/.gemini read-only for settings, then
- * delegates the spawn. Nothing is written back to the host.
- */
+/** Runs the agy container with the host token injected and ~/.gemini mounted read-only. */
 export async function runAntigravityContainer(options: RunAntigravityContainerOptions): Promise<number> {
   const creds = await resolveAntigravityCredentials()
 
@@ -26,8 +22,7 @@ export async function runAntigravityContainer(options: RunAntigravityContainerOp
   if(creds.token) extraEnv.AGY_OAUTH_TOKEN = creds.token
   if(creds.apiKey) extraEnv.ANTIGRAVITY_API_KEY = creds.apiKey
 
-  // Mount ~/.gemini read-only for settings/context (skipped if missing — `-v` would
-  // otherwise create an empty root-owned dir). The token comes via env, not this mount.
+  // Skipped when missing, or `-v` would create an empty root-owned dir.
   const extraMounts: ExtraMount[] = []
   const geminiExists = await access(GEMINI_DIR).then(() => true).catch(() => false)
   if(geminiExists) extraMounts.push([GEMINI_DIR, "/home/viber/.gemini-host", "ro"])

--- a/src/providers/ccr/run-ccr-container.ts
+++ b/src/providers/ccr/run-ccr-container.ts
@@ -5,26 +5,10 @@ import { spawnContainer } from "../../utils/container"
 import type { ExtraMount } from "../../utils/container"
 import { loadDotEnv, extractVarTokens } from "../../utils/env-file"
 import { CCR_PROVIDER_SPEC } from "./spec"
-// Single source of truth for the starter config (shared with the container entrypoint, which
-// reads the same file copied into the image). Bun inlines this JSON at build time, so the
-// bundled CLI has no runtime dependency on the asset path.
+// Bun inlines this at build time, so the bundled CLI has no runtime dependency on the asset.
 import STARTER_CONFIG from "../../assets/ccr-starter-config.json"
 
-/**
- * Minimal starter config written to the HOST when none exists, so the user has a real,
- * persistent, editable file (the container mount is read-only). APIKEY is a dummy that CCR
- * forwards to Claude Code as its auth token so it skips the onboarding wizard. Defaults to a
- * free, tool-calling OpenRouter model (runs with just $OPENROUTER_API_KEY in the project .env,
- * no --local); a local MLX provider is included to switch to if you run one (needs --local).
- * The literal lives in src/assets/ccr-starter-config.json — edit it there.
- */
-
-/**
- * Ensures a CCR config exists ON THE HOST. If ~/.claude-code-router/config.json is
- * absent, writes the starter there (never overwrites an existing file) so it persists
- * and the user can edit it — then it gets mounted read-only and mirrored into the
- * container like any real config. Returns true if it scaffolded.
- */
+/** Writes the starter config to the host when none exists, so it persists and is editable. */
 async function ensureHostConfig(): Promise<boolean> {
   const exists = await access(CCR_CONFIG_PATH).then(() => true).catch(() => false)
   if(exists) return false
@@ -33,10 +17,7 @@ async function ensureHostConfig(): Promise<boolean> {
   return true
 }
 
-/**
- * Warns when a config still uses the CCR 2.x schema. The container translates it on the fly;
- * this only tells the user what changed. The host file is never modified.
- */
+/** Warns when a config still uses the CCR 2.x schema; the host file is never modified. */
 function warnOnLegacyConfig(raw: string): void {
   let config: Record<string, unknown>
   try {
@@ -71,10 +52,7 @@ function warnOnLegacyConfig(raw: string): void {
   }
 }
 
-/**
- * Drops `_`-prefixed keys before the config is scanned for `$VAR` references, so prose in a
- * `_comment` (the scaffolded starter documents `$VAR` forwarding) can't register as a variable.
- */
+/** Drops `_`-prefixed keys so prose in a `_comment` can't register as a `$VAR` reference. */
 function stripCommentKeys(raw: string): string {
   try {
     const config: Record<string, unknown> = JSON.parse(raw)
@@ -97,22 +75,10 @@ export interface RunCcrContainerOptions {
   local?: boolean
 }
 
-/**
- * Runs the CCR (claude-code-router) container.
- *
- * Env forwarding is strict least-privilege: we parse the host's config.json for
- * `$VAR`/`${VAR}` tokens and forward ONLY those, each resolved from the project .env
- * first then the host env (.env wins). Nothing referenced → nothing forwarded; .env is
- * never blanket-forwarded. When no host config exists we scaffold a starter ON THE HOST
- * (so it persists and is editable), then mount the dir read-only; the entrypoint mirrors
- * it into a writable copy. With `local`, a single --add-host flag lets the container reach
- * host-machine models (e.g. Ollama) — no published ports, no host-network mode. CCR's
- * local server stays on 127.0.0.1.
- */
+/** Runs the CCR container, forwarding only the env vars its config references (.env wins). */
 export async function runCcrContainer(options: RunCcrContainerOptions): Promise<number> {
   const dotEnv = await loadDotEnv(process.cwd())
 
-  // Give the user a real, editable config on the host if they have none yet.
   if(await ensureHostConfig()) {
     const consumedByCcr = await access(CCR_CONFIG_SQLITE_PATH).then(() => true).catch(() => false)
     if(consumedByCcr) {
@@ -126,9 +92,7 @@ export async function runCcrContainer(options: RunCcrContainerOptions): Promise<
     }
   }
 
-  // Discover which env vars the active config references (empty if unreadable). This only works
-  // because the container always starts with no CCR sqlite store: interpolation happens on
-  // CCR's legacy-JSON import path alone. Persisting that store would silently break it.
+  // Interpolation happens on CCR's legacy-JSON import path alone, hence the sqlite-free start.
   const configRaw = await readFile(CCR_CONFIG_PATH, "utf-8").catch(() => "")
   if(configRaw) warnOnLegacyConfig(configRaw)
   const referenced = extractVarTokens(stripCommentKeys(configRaw))
@@ -151,18 +115,12 @@ export async function runCcrContainer(options: RunCcrContainerOptions): Promise<
     console.warn(`  ⚠ Unresolved CCR config var(s): ${missing.join(", ")}. CCR will substitute empty values — set them in .env or your shell.`)
   }
 
-  // Note: we do NOT inject Anthropic credentials. CCR talks to its providers using the
-  // keys in its own config; Claude Code only needs CCR's local endpoint + dummy token.
-  // A real Claude.ai subscription token here could make Claude bypass CCR entirely.
-
   const extraArgs: string[] = []
   if(options.local) {
     extraArgs.push("--add-host=host.docker.internal:host-gateway")
     console.info("  --local: adding host-gateway DNS entry (reach host models via http://host.docker.internal:<port>).")
   }
 
-  // Mount the host config dir read-only (always present — ensureHostConfig created it
-  // if absent). The entrypoint mirrors it into a writable copy inside the container.
   const extraMounts: ExtraMount[] = []
   const configDirExists = await access(CCR_CONFIG_DIR).then(() => true).catch(() => false)
   if(configDirExists) extraMounts.push([CCR_CONFIG_DIR, "/home/viber/.claude-code-router-host", "ro"])

--- a/src/providers/claude/credentials.ts
+++ b/src/providers/claude/credentials.ts
@@ -3,11 +3,7 @@ import { join } from "path"
 import { $ } from "bun"
 import { CLAUDE_DIR, CLAUDE_JSON_PATH } from "../../constants"
 
-/**
- * Reads ~/.claude.json and returns its raw contents if it contains a claudeAiOauth field.
- * Returns null when the file is missing, unreadable, or doesn't carry auth tokens.
- * Claude 2.1.63+ stores credentials there (not in ~/.claude/.credentials.json).
- */
+/** Reads ~/.claude.json, the primary credential store since Claude 2.1.63, or null. */
 export async function readClaudeJson(): Promise<string | null> {
   const exists = await access(CLAUDE_JSON_PATH, constants.R_OK).then(() => true).catch(() => false)
   if(!exists) return null
@@ -23,20 +19,14 @@ export async function readClaudeJson(): Promise<string | null> {
   }
 }
 
-/**
- * Returns the credentials JSON string to inject into the container via env var.
- * Cascade: ~/.claude.json → macOS keychain (darwin) → legacy ~/.claude/.credentials.json.
- * Exits the process (code 1) when no credential source is reachable.
- */
+/** Resolves credentials to inject: ~/.claude.json → macOS keychain → legacy file, else exits. */
 export async function resolveClaudeCredentials(): Promise<string | null> {
-  // Primary: read from ~/.claude.json (Claude 2.1.63+, works on all platforms)
   const fromFile = await readClaudeJson()
   if(fromFile) {
     console.info("  Credentials read from ~/.claude.json.")
     return fromFile
   }
 
-  // macOS fallback: pull from keychain (older Claude or fresh install)
   if(process.platform === "darwin") {
     console.info("  ~/.claude.json not found. Trying macOS keychain…")
     try {
@@ -54,7 +44,6 @@ export async function resolveClaudeCredentials(): Promise<string | null> {
     }
   }
 
-  // Linux: check old .credentials.json location as last resort
   const legacyFile = join(CLAUDE_DIR, ".credentials.json")
   const legacyExists = await access(legacyFile, constants.R_OK).then(() => true).catch(() => false)
   if(legacyExists) {

--- a/src/providers/claude/run-claude-container.ts
+++ b/src/providers/claude/run-claude-container.ts
@@ -12,18 +12,13 @@ export interface RunClaudeContainerOptions {
   gitConfig: GitIdentity | null
 }
 
-/**
- * Runs the Claude container: resolves the host's Claude credentials, mounts
- * ~/.claude read-only at /home/viber/.claude-host, injects CLAUDE_CREDENTIALS,
- * and delegates the actual spawn to the generic helper.
- */
+/** Runs the Claude container with the host's credentials and ~/.claude mounted read-only. */
 export async function runClaudeContainer(options: RunClaudeContainerOptions): Promise<number> {
   const credentialsJson = await resolveClaudeCredentials()
 
   const extraEnv: Record<string, string> = {}
   if(credentialsJson) {
-    // entrypoint.ts reads this and writes credentials inside the container —
-    // nothing is ever written back to the host's ~/.claude.
+    // The entrypoint writes these inside the container; the host's ~/.claude is never touched.
     extraEnv.CLAUDE_CREDENTIALS = credentialsJson
   }
 

--- a/src/providers/codex/credentials.ts
+++ b/src/providers/codex/credentials.ts
@@ -1,12 +1,7 @@
 import { access, constants, readFile } from "fs/promises"
 import { CODEX_AUTH_PATH } from "../../constants"
 
-/**
- * Reads ~/.codex/auth.json and returns its raw contents if it carries auth material
- * (ChatGPT OAuth tokens or an API key). Returns null when the file is missing,
- * unreadable, or doesn't parse. Codex stores auth as plaintext JSON on every
- * platform — no keychain, so this single file is the whole cascade.
- */
+/** Reads ~/.codex/auth.json — plaintext on every platform, so the whole cascade — or null. */
 export async function readCodexAuthJson(): Promise<string | null> {
   const exists = await access(CODEX_AUTH_PATH, constants.R_OK).then(() => true).catch(() => false)
   if(!exists) return null
@@ -22,10 +17,7 @@ export async function readCodexAuthJson(): Promise<string | null> {
   }
 }
 
-/**
- * Returns the auth JSON string to inject into the container via env var.
- * Exits the process (code 1) when ~/.codex/auth.json is missing or carries no auth.
- */
+/** Resolves the auth JSON to inject, or exits (code 1) when none is readable. */
 export async function resolveCodexCredentials(): Promise<string | null> {
   const fromFile = await readCodexAuthJson()
   if(fromFile) {

--- a/src/providers/codex/run-codex-container.ts
+++ b/src/providers/codex/run-codex-container.ts
@@ -12,18 +12,13 @@ export interface RunCodexContainerOptions {
   gitConfig: GitIdentity | null
 }
 
-/**
- * Runs the Codex container: resolves the host's Codex auth, mounts
- * ~/.codex read-only at /home/viber/.codex-host, injects CODEX_CREDENTIALS,
- * and delegates the actual spawn to the generic helper.
- */
+/** Runs the Codex container with the host's auth and ~/.codex mounted read-only. */
 export async function runCodexContainer(options: RunCodexContainerOptions): Promise<number> {
   const credentialsJson = await resolveCodexCredentials()
 
   const extraEnv: Record<string, string> = {}
   if(credentialsJson) {
-    // entrypoint.ts reads this and writes auth.json inside the container —
-    // nothing is ever written back to the host's ~/.codex.
+    // The entrypoint writes auth.json inside the container; the host's ~/.codex is untouched.
     extraEnv.CODEX_CREDENTIALS = credentialsJson
   }
 

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -28,10 +28,7 @@ export const PROVIDER_SPECS: Partial<Record<ProviderId, ProviderSpec>> = {
   vibe: VIBE_PROVIDER_SPEC
 }
 
-/**
- * Returns the runner registered for `providerId`, or exits the process (code 1)
- * with a helpful message if it isn't implemented yet.
- */
+/** Returns the runner for `providerId`, or exits (code 1) if it isn't implemented. */
 export function resolveProviderRunner(providerId: ProviderId): ProviderRunner {
   const runner = PROVIDER_RUNNERS[providerId]
   if(!runner) {
@@ -41,10 +38,7 @@ export function resolveProviderRunner(providerId: ProviderId): ProviderRunner {
   return runner
 }
 
-/**
- * Returns the spec registered for `providerId`, or exits the process (code 1)
- * if it isn't implemented yet. Used by the generic image helpers.
- */
+/** Returns the spec for `providerId`, or exits (code 1) if it isn't implemented. */
 export function resolveProviderSpec(providerId: ProviderId): ProviderSpec {
   const spec = PROVIDER_SPECS[providerId]
   if(!spec) {

--- a/src/providers/vibe/credentials.ts
+++ b/src/providers/vibe/credentials.ts
@@ -6,12 +6,7 @@ import { readKeyringSecret } from "../../utils/keyring"
 const KEYRING_SERVICES = ["ai.mistral.vibe", "vibe"] as const
 const API_KEY_ENV_VAR = "MISTRAL_API_KEY"
 
-/**
- * Resolves the host's Mistral API key, mirroring vibe's own persistence order:
- * MISTRAL_API_KEY env → OS keyring (service ai.mistral.vibe, legacy "vibe") → ~/.vibe/.env.
- * The runner injects it as MISTRAL_API_KEY, which vibe reads process-env-first inside
- * the container. Exits the process (code 1) when nothing is found.
- */
+/** Resolves the Mistral API key in vibe's own order: env → keyring → ~/.vibe/.env, else exits. */
 export async function resolveVibeCredentials(): Promise<string> {
   const fromEnv = process.env[API_KEY_ENV_VAR]
   if(fromEnv) {

--- a/src/providers/vibe/run-vibe-container.ts
+++ b/src/providers/vibe/run-vibe-container.ts
@@ -14,17 +14,11 @@ export interface RunVibeContainerOptions {
   gitConfig: GitIdentity | null
 }
 
-/**
- * Runs the Mistral Vibe container: resolves the host's Mistral API key, mounts
- * ~/.vibe read-only at /home/viber/.vibe-host (only when it exists — an env-key-only
- * host may not have one), injects MISTRAL_API_KEY, and delegates the actual spawn
- * to the generic helper.
- */
+/** Runs the Vibe container with the host's API key and ~/.vibe mounted read-only if present. */
 export async function runVibeContainer(options: RunVibeContainerOptions): Promise<number> {
   const apiKey = await resolveVibeCredentials()
 
-  // vibe reads MISTRAL_API_KEY process-env-first, so it beats anything mirrored from the
-  // host. SECURE_VIBE_HOST_HOME lets the entrypoint remap host paths baked into config.toml.
+  // vibe reads MISTRAL_API_KEY process-env-first, so it beats anything mirrored from the host.
   const extraEnv: Record<string, string> = {
     MISTRAL_API_KEY: apiKey,
     SECURE_VIBE_HOST_HOME: homedir()

--- a/src/utils/args.ts
+++ b/src/utils/args.ts
@@ -2,14 +2,7 @@ import type { ParsedArgs, ProviderId } from "../types"
 import type { BooleanFlag, ValueFlag } from "../constants"
 import { FLAGS, PROVIDER_FLAGS } from "../constants"
 
-/**
- * Parses process.argv into a ParsedArgs object. Unknown flags are silently ignored.
- * The first positional becomes `directory`; remaining positionals join into `command`
- * (unless --command was passed explicitly).
- *
- * Boolean/value flags are driven by the shared FLAGS spec (src/constants/flags.ts),
- * the same source the dynamic completion handler reads — so the two never drift.
- */
+/** Parses process.argv per the FLAGS spec: first positional is `directory`, the rest `command`. */
 export function parseArgs(): ParsedArgs {
   const argv = process.argv.slice(2)
   const positionals: string[] = []
@@ -47,7 +40,6 @@ export function parseArgs(): ParsedArgs {
     }
 
     if(!argument.startsWith("-")) positionals.push(argument)
-    // Unknown flags are ignored
   }
 
   return {

--- a/src/utils/completion.ts
+++ b/src/utils/completion.ts
@@ -1,11 +1,7 @@
 import type { ValueFlag } from "../constants"
 import { FLAGS, COMPLETABLE_PROVIDER_FLAGS } from "../constants"
 
-/**
- * Sentinel emitted to tell the shell stub to *also* offer directory completion
- * (the directory positional). Kept here so the stub generator (scripts/completion.ts)
- * imports the exact same token — no drift between the two sides.
- */
+/** Sentinel telling the shell stub to also offer directory completion. */
 export const DIRS_DIRECTIVE = "__SV_DIRS__"
 
 /** Resolves a flag name to its ValueFlag spec, or undefined if it isn't a value-taking flag. */
@@ -14,27 +10,15 @@ function findValueFlag(name: string | undefined): ValueFlag | undefined {
   return FLAGS.find((flag): flag is ValueFlag => flag.kind === "value" && flag.name === name)
 }
 
-/**
- * Given the words typed so far, decides whether the cursor is positioned to complete
- * a value-flag's value. Handles the `--flag value` (space) form and the `--flag=value`
- * form, which bash splits on "=" into separate words by default.
- */
+/** Decides whether the cursor sits on a value-flag's value, in either `--flag=v` or `--flag v` form. */
 function activeValueFlag(words: string[]): ValueFlag | undefined {
   const count = words.length
-  // `--flag = <value?>` — bash split the "=" into its own word.
   if(words.at(count - 2) === "=") return findValueFlag(words.at(count - 3))
   if(words.at(count - 1) === "=") return findValueFlag(words.at(count - 2))
-  // `--flag <value>` — space form; the flag is the previous word.
   return findValueFlag(words.at(count - 2))
 }
 
-/**
- * Dynamic-completion handler invoked by the installed shell stub on every TAB
- * (`secure-vibe __complete <words…>`). Prints candidate suggestions one per line;
- * the shell stub filters them by the current partial word. All suggestions come
- * straight from the live FLAGS spec (src/constants/flags.ts), so completion never
- * goes stale as flags evolve — upgrading the tool updates completion automatically.
- */
+/** Handles `secure-vibe __complete <words…>`, printing FLAGS-derived candidates one per line. */
 export function runCompletion(words: string[]): void {
   const current = words.at(-1) ?? ""
 

--- a/src/utils/container.ts
+++ b/src/utils/container.ts
@@ -16,12 +16,7 @@ export interface SpawnContainerOptions {
   extraArgs?: ReadonlyArray<string>
 }
 
-/**
- * Spawns the provider container with the shared scaffolding every CLI needs:
- * workdir mount, brew volume, host git identity. The caller layers on
- * provider-specific env vars (e.g. CLAUDE_CREDENTIALS) and bind mounts.
- * Returns the container's exit code.
- */
+/** Spawns the provider container with the shared workdir mount, brew volume and git identity. */
 export async function spawnContainer(options: SpawnContainerOptions): Promise<number> {
   const { runtime, spec, workDir, gitConfig, command, extraEnv = {}, extraMounts = [], extraArgs = [] } = options
 
@@ -45,14 +40,12 @@ export async function spawnContainer(options: SpawnContainerOptions): Promise<nu
     args.push("-e", `${key}=${value}`)
   }
 
-  // Extra docker-run flags must attach to `docker run` (before the image name),
-  // not the in-container command that follows it.
+  // Must attach to `docker run`, before the image name, not the command that follows it.
   args.push(...extraArgs)
 
   args.push(spec.imageName)
 
   if(command !== null) {
-    // Wrap in bash -c if the command contains shell metacharacters or whitespace.
     if(/[\s&|;<>$]/.test(command)) {
       args.push("bash", "-c", command)
     } else {

--- a/src/utils/env-file.ts
+++ b/src/utils/env-file.ts
@@ -1,20 +1,7 @@
 import { readFile } from "fs/promises"
 import { join } from "path"
 
-/**
- * Minimal, dependency-free `.env` reader. The project has no dotenv dependency and
- * we don't want one — this only needs to be a lookup source for env-var *names* that
- * a CCR config.json references via `$VAR`/`${VAR}`. It does NOT mutate process.env and
- * performs NO `$` expansion of values inside the file.
- *
- * Parsing rules (intentionally conservative):
- *   - Skip blank lines and lines whose first non-space char is `#`.
- *   - Split each line on the FIRST `=`; trim the key.
- *   - Accept only keys matching ^[A-Za-z_][A-Za-z0-9_]*$ (silently skip others).
- *   - Trim the value, then strip ONE matching surrounding quote pair ("…" or '…').
- *
- * Returns {} when <dir>/.env is missing or unreadable.
- */
+/** Minimal `.env` reader: no process.env mutation, no `$` expansion, {} when unreadable. */
 export async function loadDotEnv(dir: string): Promise<Record<string, string>> {
   const raw = await readFile(join(dir, ".env"), "utf-8").catch(() => null)
   if(raw === null) return {}
@@ -39,11 +26,7 @@ export async function loadDotEnv(dir: string): Promise<Record<string, string>> {
   return result
 }
 
-/**
- * Returns the unique set of env-var names referenced as `$VAR` or `${VAR}` in `text`.
- * Used to discover which variables a CCR config.json wants interpolated, so the runner
- * can forward exactly those (least privilege) and nothing else.
- */
+/** Returns the unique env-var names referenced as `$VAR` or `${VAR}` in `text`. */
 export function extractVarTokens(text: string): string[] {
   const names = new Set<string>()
   const pattern = /\$\{?([A-Za-z_][A-Za-z0-9_]*)\}?/g

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -3,7 +3,7 @@ import { BANNED_DIRS } from "../constants"
 
 /** Returns true if `path` resolves to a directory. Missing paths return false silently; other stat errors are logged at debug. */
 export async function isDirectory(path: string): Promise<boolean> {
-  // Bun.file(path).exists() reports false for directories in some Bun versions, so use fs.access.
+  // Bun.file().exists() reports false for directories in some Bun versions.
   const accessible = await access(path).then(() => true).catch(() => false)
   if(!accessible) return false
   try {

--- a/src/utils/git-identity.ts
+++ b/src/utils/git-identity.ts
@@ -15,14 +15,9 @@ async function tryGitConfig(args: string[]): Promise<string | null> {
   }
 }
 
-/**
- * Resolves the host git identity (user.name + user.email), preferring local repo
- * config, then global. Falls back to a hard-coded "Claude" identity if neither is set
- * — and logs the fallback in red so it's visible.
- */
+/** Resolves the host git identity, falling back to a hard-coded "Claude" one when unset. */
 export async function resolveGitConfig(): Promise<GitIdentity> {
-  // git config (no flag) reads local → global → system automatically.
-  // Fall back to --global explicitly in case the cwd is not a repo.
+  // No flag reads local → global → system; --global covers the cwd not being a repo.
   const name = (await tryGitConfig(["user.name"])) ?? (await tryGitConfig(["--global", "user.name"]))
   const email = (await tryGitConfig(["user.email"])) ?? (await tryGitConfig(["--global", "user.email"]))
 

--- a/src/utils/image.ts
+++ b/src/utils/image.ts
@@ -4,9 +4,7 @@ import { $ } from "bun"
 import { PROJECT_DIR } from "../constants"
 import type { Runtime, ProviderSpec } from "../types"
 
-/**
- * Builds `spec.imageName` from `spec.dockerfilePath`.
- */
+/** Builds `spec.imageName` from `spec.dockerfilePath`. */
 async function buildImage(runtime: Runtime, spec: ProviderSpec, noCache: boolean): Promise<void> {
   const buildArgs = [
     runtime, "build",
@@ -43,11 +41,7 @@ async function getLocalDigest(runtime: Runtime, image: string): Promise<string |
   return digest.startsWith("sha256:") ? digest : null
 }
 
-/**
- * Remote index digest (sha256:…) of `image` without pulling layers.
- * Uses `docker buildx imagetools inspect`; returns null on any failure or on
- * runtimes without buildx (e.g. podman), so callers fall back to a plain pull.
- */
+/** Remote index digest of `image` without pulling layers, or null on runtimes without buildx. */
 async function getRemoteDigest(runtime: Runtime, image: string): Promise<string | null> {
   if(runtime !== "docker") return null
   const { stdout, exitCode } = await $`${runtime} buildx imagetools inspect ${image} --format ${"{{.Manifest.Digest}}"}`.quiet().nothrow()
@@ -56,10 +50,7 @@ async function getRemoteDigest(runtime: Runtime, image: string): Promise<string 
   return digest.startsWith("sha256:") ? digest : null
 }
 
-/**
- * Once a day, attempts a pull and reports whether the image actually changed.
- * Cache file lives at `spec.imageCheckCachePath`. Best-effort — failures are warnings.
- */
+/** Once a day, pulls and reports whether the image changed. Best-effort. */
 async function checkForUpdates(runtime: Runtime, spec: ProviderSpec): Promise<void> {
   const today = new Date().toISOString().slice(0, 10)
   const cacheFile = Bun.file(spec.imageCheckCachePath)
@@ -106,11 +97,7 @@ async function checkForUpdates(runtime: Runtime, spec: ProviderSpec): Promise<vo
   await Bun.write(spec.imageCheckCachePath, today)
 }
 
-/**
- * Ensures `spec.imageName` is available locally. Honors --build / --build-no-cache / --pull.
- * Without flags: inspects locally; if found, daily-checks for updates; if missing, pulls;
- * if pull fails, falls back to a Dockerfile build.
- */
+/** Ensures `spec.imageName` is available locally, building from the Dockerfile if a pull fails. */
 export async function ensureImage(
   runtime: Runtime,
   spec: ProviderSpec,

--- a/src/utils/keyring.ts
+++ b/src/utils/keyring.ts
@@ -1,10 +1,6 @@
 import { $ } from "bun"
 
-/**
- * Reads a secret from the platform keyring. macOS: Keychain via `security`.
- * Linux: Secret Service (gnome-keyring/KWallet) via `secret-tool` (needs libsecret-tools).
- * Returns null when the platform is unsupported or the secret is absent/unreadable.
- */
+/** Reads a secret from the platform keyring (macOS `security`, Linux `secret-tool`), or null. */
 export async function readKeyringSecret(service: string, account: string): Promise<string | null> {
   if(process.platform === "darwin") {
     const raw = await $`security find-generic-password -s ${service} -a ${account} -w`

--- a/src/utils/save-directory.ts
+++ b/src/utils/save-directory.ts
@@ -2,11 +2,7 @@ import { dirname, basename, join } from "path"
 import type { RunScrollingOptions, SaveAction } from "../types"
 import { timestamp } from "./fs"
 
-/**
- * Runs a child process. On a TTY, streams the last `windowSize` lines in place
- * (overwriting), so long tools like rsync don't flood the screen. Non-TTY falls
- * back to direct inherited stdio. Returns the child's exit code.
- */
+/** Runs a child process, streaming the last `windowSize` lines in place when on a TTY. */
 async function runScrolling(args: string[], opts: RunScrollingOptions = {}): Promise<number> {
   const { cwd, windowSize = 5 } = opts
 
@@ -46,10 +42,7 @@ async function runScrolling(args: string[], opts: RunScrollingOptions = {}): Pro
   return childProc.exited
 }
 
-/**
- * Backs up `workDir` next to itself, either as a .zip archive or as a directory copy
- * via rsync. Errors are logged, not thrown — the orchestrator still proceeds.
- */
+/** Backs up `workDir` next to itself as a .zip or an rsync copy. Errors are logged, not thrown. */
 export async function saveDirectory(workDir: string, mode: SaveAction): Promise<void> {
   const parent = dirname(workDir)
   const name = basename(workDir)

--- a/src/utils/secrets.ts
+++ b/src/utils/secrets.ts
@@ -9,10 +9,7 @@ export function parseExcludePatterns(raw: string): string[] {
   return raw.split(",").map(pattern => pattern.trim()).filter(pattern => pattern.length > 0)
 }
 
-/**
- * Resolves the union of files matching the given patterns under `workDir`.
- * Bare names (no wildcards, no path separator) that are directories are included as a unit.
- */
+/** Resolves the union of files matching `patterns` under `workDir`. */
 export async function resolveExcludedFiles(workDir: string, patterns: string[]): Promise<string[]> {
   const seen = new Set<string>()
   for(const pattern of patterns) {
@@ -20,9 +17,7 @@ export async function resolveExcludedFiles(workDir: string, patterns: string[]):
     for await(const relPath of glob.scan({ cwd: workDir, onlyFiles: true, dot: true })) {
       seen.add(relPath)
     }
-    // Bare names (no wildcards or path separators) may be directories — move them as a unit.
-    // Guard with access() so a missing pattern is a silent no-op (the glob.scan above already
-    // covered the file case); stat-level failures get a debug log.
+    // Bare names may be directories, which glob.scan above does not cover; move them as a unit.
     if(!pattern.includes("*") && !pattern.includes("/")) {
       const targetPath = join(workDir, pattern)
       const targetExists = await access(targetPath).then(() => true).catch(() => false)
@@ -45,11 +40,7 @@ export async function isGitIgnored(workDir: string, relPath: string): Promise<bo
   return exitCode === 0
 }
 
-/**
- * Moves each path in `relPaths` out of `workDir` into a sibling secrets directory,
- * flattening "/" → "__" so subdirectories don't collide. Writes a manifest.json that
- * moveSecretsBack uses to restore them. Returns the secrets-dir path.
- */
+/** Moves `relPaths` into a sibling secrets directory, with a manifest for moveSecretsBack. */
 export async function moveSecretsOut(workDir: string, relPaths: string[]): Promise<string> {
   const secretsDir = join(dirname(workDir), `${basename(workDir)}-${timestamp()}-secrets`)
   await mkdir(secretsDir, { recursive: true })
@@ -71,10 +62,7 @@ export async function moveSecretsOut(workDir: string, relPaths: string[]): Promi
   return secretsDir
 }
 
-/**
- * Restores files previously displaced by moveSecretsOut, using the manifest written there.
- * Leaves the secrets directory in place for the user to delete manually once verified.
- */
+/** Restores files displaced by moveSecretsOut; the secrets directory is left for the user. */
 export async function moveSecretsBack(workDir: string, secretsDir: string): Promise<void> {
   let manifest: SecretEntry[]
   try {

--- a/src/utils/select-directory.ts
+++ b/src/utils/select-directory.ts
@@ -1,10 +1,7 @@
 import { resolve } from "path"
 import { isDirectory, isBannedDirectory } from "./fs"
 
-/**
- * Resolves the working directory: null/"."/"" → cwd, otherwise absolute resolve of the input.
- * Exits the process (code 1) if the path is missing, not a directory, or in BANNED_DIRS.
- */
+/** Resolves the working directory, exiting (code 1) if it is missing or in BANNED_DIRS. */
 export async function selectDirectory(preValue: string | null): Promise<string> {
   const targetPath = (preValue === null || preValue === "." || preValue === "") ? process.cwd() : resolve(preValue)
 

--- a/src/utils/select-runtime.ts
+++ b/src/utils/select-runtime.ts
@@ -1,10 +1,7 @@
 import type { Runtime } from "../types"
 import { commandExists, testRuntime } from "./runtime-detect"
 
-/**
- * Detects which container runtime to use. Defaults to docker when both are available.
- * Exits the process (code 1) if neither runtime is reachable.
- */
+/** Detects the container runtime, preferring docker, or exits (code 1) if none is reachable. */
 export async function selectRuntime(preValue: string | null): Promise<Runtime> {
   const dockerAvailable = (await commandExists("docker")) && (await testRuntime("docker"))
   const podmanAvailable = (await commandExists("podman")) && (await testRuntime("podman"))
@@ -26,7 +23,6 @@ export async function selectRuntime(preValue: string | null): Promise<Runtime> {
     return "podman"
   }
 
-  // Both available — use preValue if it names one, otherwise default to docker.
   if(preValue !== null) {
     const normalized = preValue.toLowerCase()
     if(normalized === "docker" || normalized === "podman") {

--- a/src/utils/select-save.ts
+++ b/src/utils/select-save.ts
@@ -6,10 +6,7 @@ function isSaveMode(value: string): value is SaveMode {
   return (VALID_SAVE_MODES as readonly string[]).includes(value)
 }
 
-/**
- * Validates the --save CLI value. Null → "no" (with a hint about backups). Invalid → "no" + warning.
- * Returns the chosen mode without prompting.
- */
+/** Validates the --save value without prompting; anything unusable falls back to "no". */
 export async function selectSaveOption(preValue: string | null): Promise<SaveMode> {
   if(preValue === null) {
     console.info(`  Tip: pass --save=zip or --save=copy to back up this directory first, in case you need to roll back the CLI's changes.`)


### PR DESCRIPTION
Enforce the "comment sparingly" rule in .claude/RULES.md, which had drifted badly: multi-paragraph essays above single RUN lines, 20-30 line responsibility lists heading every entrypoint, and narration restating the line below it.

What's left is at most one short line of JSDoc per function declaration and one line above genuinely non-obvious logic (the CCR sqlite/config.json import invariant, why bun can't live under the brew volume, the pnpm --allow-build allowlist, folder-trust vs approval bypass, and so on).

The diff is comment-only apart from a missing trailing newline in claude.dockerfile. Version bumped to 3.9.1.